### PR TITLE
Add module skeleton with quick loot dialog

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,0 +1,15 @@
+{
+  "id": "pf2e-combat-quickloot",
+  "title": "PF2e Combat Quickloot",
+  "description": "Zeigt allen Spielern nach dem Kampf einen Loot-Dialog mit Sammel- und Identifikationsfunktionen.",
+  "version": "0.1.0",
+  "authors": [{ "name": "Dein Name" }],
+  "compatibility": { "minimum": "13", "verified": "13" },
+  "systems": ["pf2e"],
+  "scripts": ["scripts/quickloot.js"],
+  "styles": ["styles/quickloot.css"],
+  "packs": [],
+  "relationships": { "systems": [] },
+  "manifest": "",
+  "download": ""
+}

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -1,0 +1,71 @@
+// PF2e Combat Quickloot
+// Hook: sobald ein Kampf gelöscht wird → Loot-Dialog öffnen
+Hooks.on("deleteCombat", async combat => {
+  if (!game.user.isGM) return;
+
+  const loot = collectLoot(combat);
+  if (!loot.length) return;
+
+  const grouped = groupItems(loot);
+  const html = await renderTemplate(
+    "modules/pf2e-combat-quickloot/templates/loot-dialog.hbs",
+    { items: grouped, actors: lootActors() }
+  );
+
+  new Dialog({
+    title: "Quick Loot",
+    content: html,
+    render: dlg => activateListeners(dlg)
+  }).render(true);
+});
+
+// sammelt Items aller besiegten Gegner
+function collectLoot(combat) {
+  const loot = [];
+  for (const c of combat.combatants) {
+    const actor = c.actor;
+    if (!actor || actor.system.attributes.hp.value > 0) continue;
+    loot.push(...actor.items.contents);
+  }
+  return loot;
+}
+
+// gruppiert gleichnamige Items
+function groupItems(items) {
+  const map = {};
+  for (const item of items) {
+    const key = item.name;
+    if (!map[key]) map[key] = { item, qty: 0 };
+    map[key].qty++;
+    map[key].identified =
+      item.system.identification?.status !== "unidentified";
+    map[key].magical = item.isMagical;
+  }
+  return Object.values(map);
+}
+
+// listet mögliche Ziel-Actors auf
+function lootActors() {
+  return game.actors.filter(a => a.type === "character" && a.hasPlayerOwner);
+}
+
+// Dialog-Listener
+function activateListeners(html) {
+  html.find(".item-link").click(ev => {
+    const id = ev.currentTarget.dataset.item;
+    game.items.get(id)?.sheet.render(true);
+  });
+
+  html.find(".transfer").click(async ev => {
+    const row = ev.currentTarget.closest("tr");
+    const item = game.items.get(row.dataset.item);
+    const targetId = row.querySelector(".actor-select").value;
+    const target = game.actors.get(targetId);
+    await item?.transferToActor(target);
+  });
+
+  html.find(".identify").click(ev => {
+    const item = game.items.get(ev.currentTarget.dataset.item);
+    if (item) game.pf2e.identification.startIdentification(item, {});
+  });
+}

--- a/styles/quickloot.css
+++ b/styles/quickloot.css
@@ -1,0 +1,3 @@
+.quickloot table { width: 100%; }
+.quickloot td.actions { text-align: right; }
+.quickloot button { margin-left: 0.25rem; }

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -1,0 +1,28 @@
+<form class="quickloot">
+  <table>
+    {{#each items}}
+    <tr data-item="{{this.item.id}}">
+      <td class="item-link" data-item="{{this.item.id}}">
+        {{this.qty}} × {{#if this.identified}}{{this.item.name}}{{else}}???{{/if}}
+      </td>
+      <td>
+        <select class="actor-select">
+          {{#each ../actors}}
+            <option value="{{this.id}}">{{this.name}}</option>
+          {{/each}}
+        </select>
+      </td>
+      <td class="actions">
+        {{#if this.magical}}
+          <button type="button" class="identify" data-item="{{this.item.id}}" title="Identifizieren">
+            <i class="fas fa-eye"></i>
+          </button>
+        {{/if}}
+        <button type="button" class="transfer" title="Übertragen">
+          <i class="fas fa-hand-holding"></i>
+        </button>
+      </td>
+    </tr>
+    {{/each}}
+  </table>
+</form>


### PR DESCRIPTION
## Summary
- add Foundry module manifest
- implement quick loot logic and dialog template
- include minimal styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f7908abc88327af9847d8670caf7b