### PR TITLE
Add buttons property to quick loot dialog

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -15,6 +15,7 @@ Hooks.on("deleteCombat", async combat => {
   new Dialog({
     title: "Quick Loot",
     content: html,
+    buttons: {},
     render: dlg => activateListeners(dlg)
   }).render(true);
 });


### PR DESCRIPTION
## Summary
- Add an empty `buttons` configuration to the quick loot dialog so it can render without errors

## Testing
- `node --check scripts/quickloot.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a05018bf248327a279288a0264da76