### PR TITLE
Ensure dialog has default button

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -15,7 +15,8 @@ Hooks.on("deleteCombat", async combat => {
   new Dialog({
     title: "Quick Loot",
     content: html,
-    buttons: {},
+    buttons: { close: { label: "OK" } },
+    default: "close",
     render: dlg => activateListeners(dlg)
   }).render(true);
 });


### PR DESCRIPTION
## Summary
- Add OK button and default selection to quickloot dialog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c74d44fc8327bc04990e6f75fa08