### PR TITLE
Filter non-treasure and equipped items from combat loot

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -26,7 +26,11 @@ function collectLoot(combat) {
   for (const c of combat.combatants) {
     const actor = c.actor;
     if (!actor || actor.system.attributes.hp.value > 0) continue;
-    loot.push(...actor.items.contents);
+    loot.push(
+      ...actor.items.contents.filter(
+        item => item.type === "treasure" && !item.system?.equipped
+      )
+    );
   }
   return loot;
 }

--- a/tests/collectLoot.test.js
+++ b/tests/collectLoot.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+// Stub foundry environment
+global.Hooks = { on: () => {} };
+global.game = { user: { isGM: false } };
+
+// Load the script to access collectLoot
+const code = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'quickloot.js'), 'utf8');
+vm.runInThisContext(code);
+
+// Typical combat data
+const combat = {
+  combatants: [
+    {
+      actor: {
+        system: { attributes: { hp: { value: 0 } } },
+        items: {
+          contents: [
+            { name: 'Gold Coin', type: 'treasure', system: {} },
+            { name: 'Sword', type: 'weapon', system: { equipped: false } },
+            { name: 'Equipped Necklace', type: 'treasure', system: { equipped: true } },
+            { name: 'Gem', type: 'treasure', system: { equipped: false } }
+          ]
+        }
+      }
+    },
+    {
+      actor: {
+        system: { attributes: { hp: { value: 10 } } },
+        items: {
+          contents: [
+            { name: 'Alive Treasure', type: 'treasure', system: {} }
+          ]
+        }
+      }
+    }
+  ]
+};
+
+const loot = collectLoot(combat);
+
+assert.deepStrictEqual(
+  loot.map(i => i.name).sort(),
+  ['Gold Coin', 'Gem'].sort()
+);
+
+console.log('collectLoot test passed');


### PR DESCRIPTION
## Summary
- Collect loot only from defeated actors, keeping treasure items that aren't equipped
- Add a node-based test covering typical actor data

## Testing
- `node tests/collectLoot.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0c752150c8327bf87138d66436250