### PR TITLE
Improve loot grouping with unique identifiers

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -35,12 +35,18 @@ function collectLoot(combat) {
 function groupItems(items) {
   const map = {};
   for (const item of items) {
-    const key = item.name;
-    if (!map[key]) map[key] = { item, qty: 0 };
-    map[key].qty++;
-    map[key].identified =
+    const key = item.slug ?? `${item.id}|${item.name}`;
+    if (!map[key])
+      map[key] = {
+        item,
+        qty: 0,
+        name: item.slug ?? item.name
+      };
+    const entry = map[key];
+    entry.qty++;
+    entry.identified =
       item.system.identification?.status !== "unidentified";
-    map[key].magical = item.isMagical;
+    entry.magical = item.isMagical;
   }
   return Object.values(map);
 }

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -3,7 +3,7 @@
     {{#each items}}
     <tr data-item="{{this.item.id}}">
       <td class="item-link" data-item="{{this.item.id}}">
-        {{this.qty}} × {{#if this.identified}}{{this.item.name}}{{else}}???{{/if}}
+        {{this.qty}} × {{#if this.identified}}{{this.name}}{{else}}???{{/if}}
       </td>
       <td>
         <select class="actor-select">


### PR DESCRIPTION
## Summary
- Use item slug or id+name combo for grouping to avoid name collisions
- Display grouped item names based on unique identifier

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c756386c832781327e569cb845d8