### PR TITLE
Show empty loot notice in dialog

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -4,12 +4,10 @@ Hooks.on("deleteCombat", async combat => {
   if (!game.user.isGM) return;
 
   const loot = collectLoot(combat);
-  if (!loot.length) return;
-
   const grouped = groupItems(loot);
   const html = await renderTemplate(
     "modules/pf2e-combat-quickloot/templates/loot-dialog.hbs",
-    { items: grouped, actors: lootActors() }
+    { items: grouped, actors: lootActors(), hasLoot: loot.length > 0 }
   );
 
   new Dialog({

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -1,28 +1,34 @@
 <form class="quickloot">
   <table>
-    {{#each items}}
-    <tr data-item="{{this.item.id}}">
-      <td class="item-link" data-item="{{this.item.id}}">
-        {{this.qty}} × {{#if this.identified}}{{this.name}}{{else}}???{{/if}}
-      </td>
-      <td>
-        <select class="actor-select">
-          {{#each ../actors}}
-            <option value="{{this.id}}">{{this.name}}</option>
-          {{/each}}
-        </select>
-      </td>
-      <td class="actions">
-        {{#if this.magical}}
-          <button type="button" class="identify" data-item="{{this.item.id}}" title="Identifizieren">
-            <i class="fas fa-eye"></i>
+    {{#if hasLoot}}
+      {{#each items}}
+      <tr data-item="{{this.item.id}}">
+        <td class="item-link" data-item="{{this.item.id}}">
+          {{this.qty}} × {{#if this.identified}}{{this.name}}{{else}}???{{/if}}
+        </td>
+        <td>
+          <select class="actor-select">
+            {{#each ../actors}}
+              <option value="{{this.id}}">{{this.name}}</option>
+            {{/each}}
+          </select>
+        </td>
+        <td class="actions">
+          {{#if this.magical}}
+            <button type="button" class="identify" data-item="{{this.item.id}}" title="Identifizieren">
+              <i class="fas fa-eye"></i>
+            </button>
+          {{/if}}
+          <button type="button" class="transfer" title="Übertragen">
+            <i class="fas fa-hand-holding"></i>
           </button>
-        {{/if}}
-        <button type="button" class="transfer" title="Übertragen">
-          <i class="fas fa-hand-holding"></i>
-        </button>
-      </td>
-    </tr>
-    {{/each}}
+        </td>
+      </tr>
+      {{/each}}
+    {{else}}
+      <tr>
+        <td colspan="3">Keine Beute.</td>
+      </tr>
+    {{/if}}
   </table>
 </form>


### PR DESCRIPTION
## Summary
- Always show loot dialog even when there are no items
- Pass `hasLoot` flag to templates and show a "Keine Beute" placeholder when empty

## Testing
- `node tests/collectLoot.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0da85c8248327acf865e5c56541aa