### PR TITLE
Include physical items in quick loot collection

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -25,11 +25,7 @@ function collectLoot(combat) {
   for (const c of combat.combatants) {
     const actor = c.actor;
     if (!actor || actor.system.attributes.hp.value > 0) continue;
-    loot.push(
-      ...actor.items.contents.filter(
-        item => item.type === "treasure" && !item.system?.equipped
-      )
-    );
+    loot.push(...actor.items.contents.filter(item => item.isPhysical));
   }
   return loot;
 }

--- a/tests/collectLoot.test.js
+++ b/tests/collectLoot.test.js
@@ -19,10 +19,15 @@ const combat = {
         system: { attributes: { hp: { value: 0 } } },
         items: {
           contents: [
-            { name: 'Gold Coin', type: 'treasure', system: {} },
-            { name: 'Sword', type: 'weapon', system: { equipped: false } },
-            { name: 'Equipped Necklace', type: 'treasure', system: { equipped: true } },
-            { name: 'Gem', type: 'treasure', system: { equipped: false } }
+            { name: 'Gold Coin', type: 'treasure', system: {}, isPhysical: true },
+            { name: 'Sword', type: 'weapon', system: { equipped: false }, isPhysical: true },
+            {
+              name: 'Equipped Necklace',
+              type: 'treasure',
+              system: { equipped: true },
+              isPhysical: true
+            },
+            { name: 'Gem', type: 'treasure', system: { equipped: false }, isPhysical: true }
           ]
         }
       }
@@ -32,7 +37,7 @@ const combat = {
         system: { attributes: { hp: { value: 10 } } },
         items: {
           contents: [
-            { name: 'Alive Treasure', type: 'treasure', system: {} }
+            { name: 'Alive Treasure', type: 'treasure', system: {}, isPhysical: true }
           ]
         }
       }
@@ -44,7 +49,7 @@ const loot = collectLoot(combat);
 
 assert.deepStrictEqual(
   loot.map(i => i.name).sort(),
-  ['Gold Coin', 'Gem'].sort()
+  ['Gold Coin', 'Sword', 'Equipped Necklace', 'Gem'].sort()
 );
 
 console.log('collectLoot test passed');


### PR DESCRIPTION
## Summary
- collectLoot now gathers all physical items, allowing weapons and equipped gear to be looted
- update tests to expect weapons and equipped items

## Testing
- `node tests/collectLoot.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0e3a276e883278a72320a1b9dc90c