### PR TITLE
Gather loot before combat deletion

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -1,6 +1,6 @@
 // PF2e Combat Quickloot
-// Hook: sobald ein Kampf gelöscht wird → Loot-Dialog öffnen
-Hooks.on("deleteCombat", async combat => {
+// Hook: bevor ein Kampf gelöscht wird → Loot-Dialog öffnen
+Hooks.on("preDeleteCombat", async combat => {
   if (!game.user.isGM) return;
 
   const loot = collectLoot(combat);


### PR DESCRIPTION
## Summary
- Collect and display loot before a combat is deleted

## Testing
- `node tests/collectLoot.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2e60d6e7083278d7b991cdce82c6a