### PR TITLE
Add inventory dialog macro

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,13 +3,29 @@
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt allen Spielern nach dem Kampf einen Loot-Dialog mit Sammel- und Identifikationsfunktionen.",
   "version": "0.1.0",
-  "authors": [{ "name": "Kazgul1987" }],
-  "compatibility": { "minimum": "13", "verified": "13" },
-  "systems": ["pf2e"],
-  "scripts": ["scripts/quickloot.js"],
-  "styles": ["styles/quickloot.css"],
+  "authors": [
+    {
+      "name": "Kazgul1987"
+    }
+  ],
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13"
+  },
+  "systems": [
+    "pf2e"
+  ],
+  "scripts": [
+    "scripts/quickloot.js",
+    "scripts/inventory-dialog.js"
+  ],
+  "styles": [
+    "styles/quickloot.css"
+  ],
   "packs": [],
-  "relationships": { "systems": [] },
+  "relationships": {
+    "systems": []
+  },
   "manifest": "https://raw.githubusercontent.com/Kazgul1987/PF2e-Combat-Quickloot/main/module.json",
   "download": "https://github.com/Kazgul1987/PF2e-Combat-Quickloot/releases/latest/download/module.zip"
 }

--- a/scripts/inventory-dialog.js
+++ b/scripts/inventory-dialog.js
@@ -1,0 +1,35 @@
+// Inventar-Dialog anzeigen
+function showInventoryDialog() {
+  const token = canvas.tokens.controlled[0];
+  if (!token) return ui.notifications.warn("Bitte zuerst einen Token auswählen.");
+
+  const actor = token.actor;
+  const items = actor.items.filter(i => i.isPhysical);
+  const rows = items
+    .map(
+      i =>
+        `<tr data-id="${i.id}">
+           <td class="item-link">${i.quantity ?? 1} × ${i.name}</td>
+         </tr>`
+    )
+    .join("");
+
+  new Dialog({
+    title: `Inventar von ${actor.name}`,
+    content: `<form><table class="quickloot">${
+      rows || "<tr><td>Keine Items.</td></tr>"
+    }</table></form>`,
+    buttons: { close: { label: "Schließen" } },
+    render: html => {
+      html.find(".item-link").click(ev => {
+        const id = ev.currentTarget.closest("tr").dataset.id;
+        actor.items.get(id)?.sheet.render(true);
+      });
+    }
+  }).render(true);
+}
+
+Hooks.once("ready", () => {
+  game.pf2eCombatQuickloot = game.pf2eCombatQuickloot || {};
+  game.pf2eCombatQuickloot.showInventoryDialog = showInventoryDialog;
+});


### PR DESCRIPTION
## Summary
- add macro to show selected token inventory and open item sheets
- load new macro script in module manifest

## Testing
- `node tests/collectLoot.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a387b17ca48327bf0286e7292bcc31