### PR TITLE
Render NPC loot separately

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -3,11 +3,29 @@
 Hooks.on("preDeleteCombat", async combat => {
   if (!game.user.isGM) return;
 
-  const loot = collectLoot(combat);
-  const grouped = groupItems(loot);
+  const npcs = [];
+  for (const c of combat.combatants) {
+    const actor = c.actor;
+    if (!actor || actor.type !== "npc" || actor.system.attributes.hp.value > 0) continue;
+
+    const items = [];
+    for (const item of actor.items.contents.filter(i => i.isPhysical)) {
+      const mystified = (await item.getMystifiedData?.()) ?? {};
+      items.push({
+        item,
+        qty: item.quantity ?? 1,
+        name: mystified.name ?? item.name,
+        identified: item.system.identification?.status !== "unidentified",
+        magical: item.isMagical
+      });
+    }
+    npcs.push({ id: actor.id, name: actor.name, items });
+  }
+
+  const hasLoot = npcs.some(n => n.items.length > 0);
   const html = await renderTemplate(
     "modules/pf2e-combat-quickloot/templates/loot-dialog.hbs",
-    { items: grouped, actors: lootActors(), hasLoot: loot.length > 0 }
+    { npcs, actors: lootActors(), hasLoot }
   );
 
   new Dialog({
@@ -58,20 +76,25 @@ function lootActors() {
 // Dialog-Listener
 function activateListeners(html) {
   html.find(".item-link").click(ev => {
-    const id = ev.currentTarget.dataset.item;
-    game.items.get(id)?.sheet.render(true);
+    const row = ev.currentTarget.closest("tr");
+    const actor = game.actors.get(row.dataset.actor);
+    const item = actor?.items.get(row.dataset.item);
+    item?.toMessage();
   });
 
   html.find(".transfer").click(async ev => {
     const row = ev.currentTarget.closest("tr");
-    const item = game.items.get(row.dataset.item);
+    const actor = game.actors.get(row.dataset.actor);
+    const item = actor?.items.get(row.dataset.item);
     const targetId = row.querySelector(".actor-select").value;
     const target = game.actors.get(targetId);
     await item?.transferToActor(target);
   });
 
   html.find(".identify").click(ev => {
-    const item = game.items.get(ev.currentTarget.dataset.item);
+    const row = ev.currentTarget.closest("tr");
+    const actor = game.actors.get(row.dataset.actor);
+    const item = actor?.items.get(row.dataset.item);
     if (item) game.pf2e.identification.startIdentification(item, {});
   });
 }

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -1,34 +1,45 @@
 <form class="quickloot">
-  <table>
-    {{#if hasLoot}}
-      {{#each items}}
-      <tr data-item="{{this.item.id}}">
-        <td class="item-link" data-item="{{this.item.id}}">
-          {{this.qty}} × {{#if this.identified}}{{this.name}}{{else}}???{{/if}}
-        </td>
-        <td>
-          <select class="actor-select">
-            {{#each ../actors}}
-              <option value="{{this.id}}">{{this.name}}</option>
-            {{/each}}
-          </select>
-        </td>
-        <td class="actions">
-          {{#if this.magical}}
-            <button type="button" class="identify" data-item="{{this.item.id}}" title="Identifizieren">
-              <i class="fas fa-eye"></i>
-            </button>
-          {{/if}}
-          <button type="button" class="transfer" title="Übertragen">
-            <i class="fas fa-hand-holding"></i>
-          </button>
-        </td>
-      </tr>
-      {{/each}}
-    {{else}}
+  {{#if hasLoot}}
+    {{#each npcs}}
+      <h3>{{this.name}}</h3>
+      <table>
+        {{#if this.items.length}}
+          {{#each this.items}}
+            <tr data-item="{{this.item.id}}" data-actor="{{../id}}">
+              <td class="item-link" data-item="{{this.item.id}}">
+                {{this.qty}} × {{this.name}}
+              </td>
+              <td>
+                <select class="actor-select">
+                  {{#each ../../actors}}
+                    <option value="{{this.id}}">{{this.name}}</option>
+                  {{/each}}
+                </select>
+              </td>
+              <td class="actions">
+                {{#if this.magical}}
+                  <button type="button" class="identify" data-item="{{this.item.id}}" title="Identifizieren">
+                    <i class="fas fa-eye"></i>
+                  </button>
+                {{/if}}
+                <button type="button" class="transfer" title="Übertragen">
+                  <i class="fas fa-hand-holding"></i>
+                </button>
+              </td>
+            </tr>
+          {{/each}}
+        {{else}}
+          <tr>
+            <td colspan="3">Keine Beute.</td>
+          </tr>
+        {{/if}}
+      </table>
+    {{/each}}
+  {{else}}
+    <table>
       <tr>
-        <td colspan="3">Keine Beute.</td>
+        <td>Keine Beute.</td>
       </tr>
-    {{/if}}
-  </table>
+    </table>
+  {{/if}}
 </form>


### PR DESCRIPTION
## Summary
- Render each NPC's loot with mystified data and magical flags
- Display identify and transfer controls per item
- Group loot by NPC in dialog template

## Testing
- `node tests/collectLoot.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4c5e50dbc832798ae2f61943c5397