### PR TITLE
Handle stacked item quantities in loot dialog

### DIFF
--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -112,14 +112,14 @@ function groupItems(items) {
   const map = {};
   for (const item of items) {
     const key = item.slug ?? `${item.id}|${item.name}`;
-    if (!map[key])
-      map[key] = {
+    let entry = map[key];
+    if (!entry)
+      entry = map[key] = {
         item,
-        qty: 0,
+        qty: item.quantity ?? 1,
         name: item.slug ?? item.name
       };
-    const entry = map[key];
-    entry.qty++;
+    else entry.qty += item.quantity ?? 1;
     entry.identified =
       item.system.identification?.status !== "unidentified";
     entry.magical = item.isMagical;

--- a/tests/groupItems.test.js
+++ b/tests/groupItems.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+global.Hooks = { on: () => {} };
+global.game = { user: { isGM: false } };
+
+const code = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'quickloot.js'), 'utf8');
+vm.runInThisContext(code);
+
+const items = [
+  { id: 'a1', slug: 'arrow', name: 'Arrow', quantity: 10, isMagical: false, system: { identification: { status: 'identified' } } },
+  { id: 'a2', slug: 'arrow', name: 'Arrow', quantity: 5, isMagical: false, system: { identification: { status: 'identified' } } },
+  { id: 'b1', slug: 'sword', name: 'Sword', quantity: 1, isMagical: false, system: { identification: { status: 'identified' } } }
+];
+
+const grouped = groupItems(items);
+const arrowEntry = grouped.find(i => i.name === 'arrow' || i.name === 'Arrow');
+assert.strictEqual(arrowEntry.qty, 15);
+
+console.log('groupItems quantity test passed');


### PR DESCRIPTION
## Summary
- Sum item quantities when grouping loot so stacked items show correct totals
- Add unit test covering grouped item quantities

## Testing
- `node tests/collectLoot.test.js`
- `node tests/groupItems.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4c7dac85c8327a3f2128c5e5b2147