### PR TITLE
Escape item names in inventory dialog

### DIFF
--- a/scripts/inventory-dialog.js
+++ b/scripts/inventory-dialog.js
@@ -9,7 +9,7 @@ function showInventoryDialog() {
     .map(
       i =>
         `<tr data-id="${i.id}">
-           <td class="item-link">${i.quantity ?? 1} × ${i.name}</td>
+           <td class="item-link">${i.quantity ?? 1} × ${TextEditor.encodeHTML(i.name)}</td>
          </tr>`
     )
     .join("");


### PR DESCRIPTION
## Summary
- Escape item names when building inventory dialog rows to prevent HTML injection and display special characters correctly.

## Testing
- `node tests/collectLoot.test.js`
- `node - <<'NODE'
const fs = require('fs');
const path = require('path');
const vm = require('vm');
const assert = require('assert');
let dialogContent='';
class Dialog{constructor(o){dialogContent=o.content;return this;}render(){return this;}}
const actor={name:'Test Actor',items:[{id:'1',name:'<b>Ring & Amulet</b>',isPhysical:true,quantity:1}]};
global.canvas={tokens:{controlled:[{actor}]}};
global.ui={notifications:{warn:()=>{throw new Error('warn')}}};
global.TextEditor={encodeHTML:s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')};
global.Dialog=Dialog;global.Hooks={once:()=>{}};
const code=fs.readFileSync(path.join(__dirname,'scripts','inventory-dialog.js'),'utf8');
vm.runInThisContext(code);
showInventoryDialog();
assert(dialogContent.includes('&lt;b&gt;Ring &amp; Amulet&lt;/b&gt;'));
console.log('Dialog content:', dialogContent);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a4c81197fc8327b1ca12b8ace96ade