### PR TITLE
Update Quickloot for Foundry V14 — central loot dialog, secure identification and transfers

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,20 +1,17 @@
 {
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
-  "description": "Zeigt allen Spielern nach dem Kampf einen Loot-Dialog mit Sammel- und Identifikationsfunktionen.",
-  "version": "0.1.0",
+  "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
+  "version": "0.2.0",
   "authors": [
     {
       "name": "Kazgul1987"
     }
   ],
   "compatibility": {
-    "minimum": "13",
-    "verified": "13"
+    "minimum": "14",
+    "verified": "14"
   },
-  "systems": [
-    "pf2e"
-  ],
   "scripts": [
     "scripts/quickloot.js",
     "scripts/inventory-dialog.js"
@@ -24,7 +21,12 @@
   ],
   "packs": [],
   "relationships": {
-    "systems": []
+    "systems": [
+      {
+        "id": "pf2e",
+        "type": "system"
+      }
+    ]
   },
   "manifest": "https://raw.githubusercontent.com/Kazgul1987/PF2e-Combat-Quickloot/main/module.json",
   "download": "https://github.com/Kazgul1987/PF2e-Combat-Quickloot/releases/latest/download/module.zip"

--- a/scripts/inventory-dialog.js
+++ b/scripts/inventory-dialog.js
@@ -1,35 +1,31 @@
-// Inventar-Dialog anzeigen
-function showInventoryDialog() {
-  const token = canvas.tokens.controlled[0];
-  if (!token) return ui.notifications.warn("Bitte zuerst einen Token auswählen.");
+(() => {
+  "use strict";
 
-  const actor = token.actor;
-  const items = actor.items.filter(i => i.isPhysical);
-  const rows = items
-    .map(
-      i =>
-        `<tr data-id="${i.id}">
-           <td class="item-link">${i.quantity ?? 1} × ${TextEditor.encodeHTML(i.name)}</td>
-         </tr>`
-    )
-    .join("");
+  async function showInventoryDialog() {
+    const token = canvas.tokens.controlled[0];
+    if (!token?.actor) return ui.notifications.warn("Bitte zuerst einen Token auswählen.");
 
-  new Dialog({
-    title: `Inventar von ${actor.name}`,
-    content: `<form><table class="quickloot">${
-      rows || "<tr><td>Keine Items.</td></tr>"
-    }</table></form>`,
-    buttons: { close: { label: "Schließen" } },
-    render: html => {
-      html.find(".item-link").click(ev => {
-        const id = ev.currentTarget.closest("tr").dataset.id;
-        actor.items.get(id)?.sheet.render(true);
-      });
-    }
-  }).render(true);
-}
+    const actor = token.actor;
+    const rows = actor.items
+      .filter((item) => item.isPhysical === true)
+      .map((item) => {
+        const identified = item.isIdentified ?? item.system?.identification?.status === "identified";
+        const name = identified
+          ? item.name
+          : item.getMystifiedName?.() ?? item.getMystifiedData?.("unidentified")?.name ?? "Unidentifizierter Gegenstand";
+        return `<tr><td>${Number(item.quantity ?? 1)} × ${foundry.utils.escapeHTML(name)}</td></tr>`;
+      })
+      .join("");
 
-Hooks.once("ready", () => {
-  game.pf2eCombatQuickloot = game.pf2eCombatQuickloot || {};
-  game.pf2eCombatQuickloot.showInventoryDialog = showInventoryDialog;
-});
+    return foundry.applications.api.DialogV2.wait({
+      window: { title: `Inventar von ${actor.name}` },
+      content: `<table class="quickloot inventory"><tbody>${rows || "<tr><td>Keine Items.</td></tr>"}</tbody></table>`,
+      buttons: [{ action: "close", label: "Schließen", icon: "fa-solid fa-xmark", default: true }],
+    });
+  }
+
+  Hooks.once("ready", () => {
+    const namespace = (game.pf2eCombatQuickloot ??= {});
+    namespace.showInventoryDialog = showInventoryDialog;
+  });
+})();

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -1,119 +1,265 @@
-// PF2e Combat Quickloot
+/* PF2e Combat Quickloot - Foundry VTT 14 */
 
-Hooks.on("preDeleteCombat", async (combat) => {
-  if (!game.user.isGM) return;
+(() => {
+  "use strict";
 
-  const npcs = [];
-  for (const c of combat.combatants) {
-    const actor = c.actor;
-    if (
-      !actor ||
-      actor.type !== "npc" ||
-      actor.system.attributes.hp.value > 0
-    )
-      continue;
+  const MODULE_ID = "pf2e-combat-quickloot";
+  const PREFIX = "PF2e Combat Quickloot |";
+  const TEMPLATE = `modules/${MODULE_ID}/templates/loot-dialog.hbs`;
+  const TARGET_NAMES = Object.freeze(["Partystash", "Loot", "Sell"]);
 
-    const items = actor.items
-      .filter((i) => i.isPhysical)
-      .map((item) => ({
-        item,
-        qty: item.quantity ?? 1,
-        name: item.getMystifiedName?.() ?? item.name,
-        identified: item.system?.identification?.status === "identified",
-        magical: item.isMagical,
-      }));
-
-    npcs.push({
-      id: actor.id,
-      name: actor.name,
-      items: collectCachedLoot({ id: actor.id, items }),
-    });
+  function notifyError(message, error) {
+    console.error(`${PREFIX} ${message}`, error);
+    ui.notifications.error(message);
   }
 
-  const hasLoot = npcs.some((n) => n.items.length > 0);
-  const html = await renderTemplate(
-    "modules/pf2e-combat-quickloot/templates/loot-dialog.hbs",
-    {
-      npcs,
-      actors: lootActors(),
-      hasLoot,
+  /** Resolve the three deliberately fixed destinations and never return partial results. */
+  function resolveTargetActors({ notify = true } = {}) {
+    const actors = TARGET_NAMES.map((name) => game.actors.find((actor) => actor.name === name) ?? null);
+    const missing = TARGET_NAMES.filter((_name, index) => !actors[index]);
+    if (missing.length) {
+      if (notify) {
+        ui.notifications.error(
+          `${PREFIX} Folgende Ziel-Actors fehlen: ${missing.join(", ")}. Der Loot-Dialog wurde nicht geöffnet.`,
+        );
+      }
+      return null;
     }
-  );
-
-  new QuickLootDialog({
-    title: "Quick Loot",
-    content: html,
-    buttons: { ok: { label: "OK" } },
-    default: "ok",
-  }).render(true);
-});
-
-class QuickLootDialog extends Dialog {
-  activateListeners(html) {
-    super.activateListeners(html);
-
-    html.find(".item-link").click((ev) => {
-      const itemId = ev.currentTarget.closest("tr").dataset.item;
-      const actorId = ev.currentTarget.closest("tr").dataset.actor;
-      const actor = game.actors.get(actorId);
-      actor?.items.get(itemId)?.sheet.render(true);
-    });
-
-    html.find(".transfer").click(async (ev) => {
-      const tr = ev.currentTarget.closest("tr");
-      const itemId = tr.dataset.item;
-      const sourceId = tr.dataset.actor;
-      const targetId = tr.querySelector(".actor-select").value;
-      const source = game.actors.get(sourceId);
-      const target = game.actors.get(targetId);
-      const item = source?.items.get(itemId);
-      if (source && target && item) {
-        await item.transferToActor?.(target, item.quantity);
-        this.render(false);
-      }
-    });
-
-    html.find(".identify").click(async (ev) => {
-      const tr = ev.currentTarget.closest("tr");
-      const itemId = tr.dataset.item;
-      const actorId = tr.dataset.actor;
-      const actor = game.actors.get(actorId);
-      const item = actor?.items.get(itemId);
-      if (item) {
-        await item.setIdentificationStatus?.("identified");
-        this.render(false);
-      }
-    });
+    return new Map(actors.map((actor) => [actor.name, actor]));
   }
-}
 
-function lootActors() {
-  return game.actors
-    .filter((a) => a.hasPlayerOwner && a.type === "character")
-    .map((a) => ({ id: a.id, name: a.name }));
-}
+  function isDefeated(combatant) {
+    return combatant.defeated === true || Number(combatant.actor?.system?.attributes?.hp?.value) <= 0;
+  }
 
-const _lootCache = new Map();
-
-function collectCachedLoot({ id, items }) {
-  const cached = _lootCache.get(id) ?? [];
-  const grouped = groupItems([...cached, ...items]);
-  _lootCache.delete(id);
-  return grouped;
-}
-
-function groupItems(items) {
-  const groups = [];
-  for (const item of items) {
-    const existing = groups.find(
-      (i) =>
-        i.item.id === item.item.id &&
-        i.identified === item.identified &&
-        i.magical === item.magical
+  function safeItemName(item) {
+    if (item.isIdentified ?? item.system?.identification?.status === "identified") return item.name;
+    return (
+      item.getMystifiedName?.() ??
+      item.getMystifiedData?.("unidentified")?.name ??
+      game.i18n.localize(`TYPES.Item.${item.type}`) ??
+      "Unidentifizierter Gegenstand"
     );
-    if (existing) existing.qty += item.qty;
-    else groups.push({ ...item });
   }
-  return groups;
-}
 
+  function collectLoot(combat) {
+    const sections = [];
+    const rows = new Map();
+
+    for (const combatant of combat.combatants) {
+      const actor = combatant.actor;
+      if (!actor || actor.type !== "npc" || !isDefeated(combatant)) continue;
+
+      const section = { name: actor.name, items: [] };
+      for (const item of actor.items.filter((candidate) => candidate.isPhysical === true)) {
+        const quantity = Number(item.quantity ?? item.system?.quantity ?? 1);
+        if (!Number.isFinite(quantity) || quantity < 1) continue;
+
+        const key = foundry.utils.randomID();
+        const identified = item.isIdentified ?? item.system?.identification?.status === "identified";
+        const row = {
+          key,
+          sourceUuid: actor.uuid,
+          itemId: item.id,
+          quantity,
+          identified,
+          identifiable: !identified && (item.isMagical || item.isAlchemical),
+        };
+        rows.set(key, row);
+        section.items.push({
+          key,
+          quantity,
+          name: safeItemName(item),
+          identified,
+          identifiable: row.identifiable,
+        });
+      }
+      if (section.items.length) sections.push(section);
+    }
+    return { sections, rows };
+  }
+
+  async function resolveSourceActor(uuid) {
+    const actor = await fromUuid(uuid);
+    return actor?.documentName === "Actor" ? actor : null;
+  }
+
+  async function transferPhysicalItem(source, target, item, quantity) {
+    if (typeof source.transferItemToActor === "function") {
+      return source.transferItemToActor(target, item, quantity);
+    }
+    if (typeof item.transferToActor === "function") {
+      return item.transferToActor(target, quantity);
+    }
+    throw new Error("Die installierte PF2e-Version stellt keine unterstützte Item-Transfer-API bereit.");
+  }
+
+  /**
+   * Adapter for PF2e's identification API. Keeping this isolated makes adding the
+   * actual skill roll and setIdentificationStatus("identified") straightforward.
+   */
+  function getIdentificationDCs(item) {
+    const api = game.pf2e?.identification;
+    const options = {
+      pwol: game.pf2e?.settings?.variants?.pwol?.enabled ?? false,
+      notMatchingTraditionModifier: game.settings.get("pf2e", "identifyMagicNotMatchingTraditionModifier"),
+    };
+    const candidates = [
+      () => item.getIdentificationDCs?.(options),
+      () => api?.getItemIdentificationDCs?.(item, options),
+      () => api?.getIdentificationDCs?.(item, options),
+    ];
+    for (const candidate of candidates) {
+      const dcs = candidate();
+      if (dcs && typeof dcs === "object") return dcs;
+    }
+    throw new Error(
+      "Die PF2e-Identification-API ist in dieser Systemversion nicht öffentlich verfügbar. Es werden bewusst keine DCs hartcodiert.",
+    );
+  }
+
+  async function postIdentificationChecks(item) {
+    const dcs = getIdentificationDCs(item);
+    const skillLabels = CONFIG.PF2E.skills ?? CONFIG.PF2E.skillList ?? {};
+    const checks = Object.entries(dcs)
+      .filter(([, dc]) => Number.isFinite(Number(dc)))
+      .map(([skill, dc]) => {
+        const label = game.i18n.localize(skillLabels[skill]?.label ?? skillLabels[skill] ?? `PF2E.Skill.${skill}`);
+        return `<li>${foundry.utils.escapeHTML(label)} DC ${Number(dc)}</li>`;
+      })
+      .join("");
+    if (!checks) throw new Error("PF2e hat für diesen Gegenstand keine möglichen Identifikations-Checks geliefert.");
+
+    // Deliberately use only mystified plain text: no UUID, link, image, price, level, traits, or description.
+    const name = foundry.utils.escapeHTML(safeItemName(item));
+    const action = item.isMagical ? "Identify Magic" : item.isAlchemical ? "Identify Alchemy" : "Identify Item";
+    await ChatMessage.create({
+      user: game.user.id,
+      content: `<section class="pf2e-quickloot-identification"><h3>${action}</h3><p>${name}</p><p><strong>Possible Checks:</strong></p><ul>${checks}</ul></section>`,
+    });
+  }
+
+  class QuickLootDialog extends foundry.applications.api.DialogV2 {
+    constructor(options, rows) {
+      super(options);
+      this.rows = rows;
+      this.distributing = false;
+    }
+
+    _onRender(context, options) {
+      super._onRender(context, options);
+      this.element.querySelectorAll("button.identify").forEach((button) => {
+        button.addEventListener("click", () => this._onIdentify(button.dataset.row));
+      });
+      this.element.querySelectorAll("button.item-link").forEach((button) => {
+        button.addEventListener("click", () => this._onOpenItem(button.dataset.row));
+      });
+    }
+
+    async _getCurrentItem(key) {
+      const row = this.rows.get(key);
+      const source = row ? await resolveSourceActor(row.sourceUuid) : null;
+      return { row, source, item: source?.items.get(row?.itemId) ?? null };
+    }
+
+    async _onOpenItem(key) {
+      const { row, item } = await this._getCurrentItem(key);
+      // Sheets are offered only for identified items. This is a second guard against forged DOM events.
+      if (row?.identified && item?.isIdentified !== false) item.sheet.render({ force: true });
+    }
+
+    async _onIdentify(key) {
+      const { row, item } = await this._getCurrentItem(key);
+      if (!row || !item) return ui.notifications.error(`${PREFIX} Der Gegenstand existiert nicht mehr.`);
+      try {
+        await postIdentificationChecks(item);
+      } catch (error) {
+        notifyError(`${PREFIX} Identifikations-Checks konnten nicht gepostet werden: ${error.message}`, error);
+      }
+    }
+
+    async distribute(event, button) {
+      event.preventDefault();
+      if (this.distributing) return false;
+      this.distributing = true;
+      button.disabled = true;
+
+      const targets = resolveTargetActors();
+      if (!targets) {
+        this.distributing = false;
+        button.disabled = false;
+        return false;
+      }
+
+      const form = this.element.querySelector("form.quickloot");
+      const failures = [];
+      for (const [key, row] of this.rows) {
+        const targetName = new FormData(form).get(`target-${key}`);
+        const target = targets.get(targetName);
+        try {
+          const source = await resolveSourceActor(row.sourceUuid);
+          const item = source?.items.get(row.itemId);
+          if (!source) throw new Error("Source-Actor existiert nicht mehr.");
+          if (!item || item.isPhysical !== true) throw new Error("Das physische Source-Item existiert nicht mehr.");
+          if (!target) throw new Error("Der ausgewählte Target-Actor existiert nicht.");
+          const quantity = Math.min(row.quantity, Number(item.quantity ?? 0));
+          if (quantity < 1) throw new Error("Die Item-Menge ist nicht mehr verfügbar.");
+          await transferPhysicalItem(source, target, item, quantity);
+          this.rows.delete(key); // A successful row can never be submitted a second time.
+        } catch (error) {
+          console.error(`${PREFIX} Transfer von Loot-Zeile ${key} fehlgeschlagen.`, error);
+          failures.push(error.message);
+        }
+      }
+
+      if (failures.length) {
+        ui.notifications.error(`${PREFIX} ${failures.length} Transfer(s) fehlgeschlagen: ${failures.join(" ")}`);
+        this.distributing = false;
+        button.disabled = false;
+        return false;
+      }
+      ui.notifications.info(`${PREFIX} Alle Items wurden verteilt.`);
+      return true;
+    }
+  }
+
+  async function showLootDialog(combat) {
+    if (!game.user.isGM) return;
+    const targets = resolveTargetActors();
+    if (!targets) return;
+    const { sections, rows } = collectLoot(combat);
+    if (!rows.size) return ui.notifications.info(`${PREFIX} Die besiegten Gegner haben keine physische Beute.`);
+
+    const content = await foundry.applications.handlebars.renderTemplate(TEMPLATE, {
+      sections,
+      targets: TARGET_NAMES,
+    });
+    const dialog = new QuickLootDialog(
+      {
+        id: `${MODULE_ID}-dialog`,
+        window: { title: "PF2e Combat Quickloot" },
+        position: { width: 760 },
+        modal: true,
+        content,
+        buttons: [
+          {
+            action: "distribute",
+            label: "Items verteilen",
+            icon: "fa-solid fa-box-open",
+            default: true,
+            callback: (event, button) => dialog.distribute(event, button),
+          },
+        ],
+      },
+      rows,
+    );
+    dialog.render({ force: true });
+  }
+
+  Hooks.on("deleteCombat", (combat) => void showLootDialog(combat).catch((error) => {
+    notifyError(`${PREFIX} Der Loot-Dialog konnte nicht geöffnet werden.`, error);
+  }));
+
+  const namespace = (game.pf2eCombatQuickloot ??= {});
+  Object.assign(namespace, { resolveTargetActors, showLootDialog });
+})();

--- a/styles/quickloot.css
+++ b/styles/quickloot.css
@@ -1,3 +1,98 @@
-.quickloot table { width: 100%; }
-.quickloot td.actions { text-align: right; }
-.quickloot button { margin-left: 0.25rem; }
+.quickloot {
+  --quickloot-border: color-mix(in srgb, var(--color-border-light-primary, #7a7971) 65%, transparent);
+  display: grid;
+  gap: 0.65rem;
+}
+
+.quickloot-section h3 {
+  margin: 0 0 0.25rem;
+  padding: 0.2rem 0.4rem;
+  border-bottom: 1px solid var(--quickloot-border);
+  font-size: 1rem;
+}
+
+.quickloot table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.quickloot th,
+.quickloot td {
+  padding: 0.25rem 0.35rem;
+  border-bottom: 1px solid var(--quickloot-border);
+  vertical-align: middle;
+}
+
+.quickloot th {
+  font-size: 0.75rem;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.quickloot .quantity {
+  width: 3.5rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.quickloot .item-name {
+  width: 100%;
+  text-align: left;
+}
+
+.quickloot button.item-link {
+  width: auto;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--color-text-hyperlink, #ff6400);
+  line-height: inherit;
+  text-align: left;
+}
+
+.quickloot .target {
+  width: 4.5rem;
+  text-align: center;
+}
+
+.quickloot .target label {
+  display: inline-grid;
+  cursor: pointer;
+  place-items: center;
+}
+
+.quickloot .target input[type="radio"] {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  accent-color: var(--color-warm-2, #d98f39);
+}
+
+.quickloot .actions {
+  width: 2.25rem;
+  text-align: center;
+}
+
+.quickloot .actions button {
+  width: 1.8rem;
+  min-height: 1.8rem;
+  margin: 0;
+  padding: 0;
+}
+
+.quickloot.inventory td {
+  text-align: left;
+}
+
+.quickloot .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -1,45 +1,46 @@
 <form class="quickloot">
-  {{#if hasLoot}}
-    {{#each npcs}}
+  {{#each sections}}
+    <section class="quickloot-section">
       <h3>{{this.name}}</h3>
       <table>
-        {{#if this.items.length}}
+        <thead>
+          <tr>
+            <th class="quantity">Menge</th>
+            <th class="item-name">Gegenstand</th>
+            {{#each ../targets}}<th class="target">{{this}}</th>{{/each}}
+            <th class="actions"><span class="sr-only">Aktionen</span></th>
+          </tr>
+        </thead>
+        <tbody>
           {{#each this.items}}
-            <tr data-item="{{this.item.id}}" data-actor="{{../id}}">
-              <td class="item-link" data-item="{{this.item.id}}">
-                {{this.qty}} × {{this.name}}
+            <tr data-row="{{this.key}}">
+              <td class="quantity">{{this.quantity}} ×</td>
+              <td class="item-name">
+                {{#if this.identified}}
+                  <button type="button" class="item-link" data-row="{{this.key}}">{{this.name}}</button>
+                {{else}}
+                  <span>{{this.name}}</span>
+                {{/if}}
               </td>
-              <td>
-                <select class="actor-select">
-                  {{#each ../../actors}}
-                    <option value="{{this.id}}">{{this.name}}</option>
-                  {{/each}}
-                </select>
-              </td>
+              {{#each ../../targets}}
+                <td class="target">
+                  <label title="{{this}}">
+                    <input type="radio" name="target-{{../key}}" value="{{this}}" {{#if @first}}checked{{/if}}>
+                    <span class="sr-only">{{this}}</span>
+                  </label>
+                </td>
+              {{/each}}
               <td class="actions">
-                {{#if this.magical}}
-                  <button type="button" class="identify" data-item="{{this.item.id}}" title="Identifizieren">
-                    <i class="fas fa-eye"></i>
+                {{#if this.identifiable}}
+                  <button type="button" class="identify" data-row="{{this.key}}" title="Mögliche Identifikations-Checks posten" aria-label="Mögliche Identifikations-Checks posten">
+                    <i class="fa-solid fa-magnifying-glass" inert></i>
                   </button>
                 {{/if}}
-                <button type="button" class="transfer" title="Übertragen">
-                  <i class="fas fa-hand-holding"></i>
-                </button>
               </td>
             </tr>
           {{/each}}
-        {{else}}
-          <tr>
-            <td colspan="3">Keine Beute.</td>
-          </tr>
-        {{/if}}
+        </tbody>
       </table>
-    {{/each}}
-  {{else}}
-    <table>
-      <tr>
-        <td>Keine Beute.</td>
-      </tr>
-    </table>
-  {{/if}}
+    </section>
+  {{/each}}
 </form>


### PR DESCRIPTION
### Motivation

- Modernize the existing PF2e Combat Quickloot module for Foundry VTT V14 and adapt to current PF2e APIs while keeping the original structure and the `game.pf2eCombatQuickloot.showInventoryDialog()` entry point.
- Provide a GM-only, post-combat shared loot dialog that safely presents physical items (including coin-like physical items) from defeated NPCs and allows batch transfer to three fixed destination actors.

### Description

- Rewrote the main loot flow to use Foundry V14 `DialogV2` and a dialog-local UUID-based row state instead of the previous `_lootCache`, collecting only defeated NPC combatants and only physical PF2e items; the new logic lives in `scripts/quickloot.js` and uses PF2e document APIs where available (`getMystifiedName`, identification data, `transferItemToActor` fallback). 
- Implemented secure mystification handling and identification workflow: unidentifed items show mystified names via PF2e APIs, item sheets are only opened for identified items, and the identify button posts the PF2e-provided possible skill checks/DCs to chat without leaking item internals or UUIDs (`scripts/quickloot.js`, `templates/loot-dialog.hbs`).
- Centralized three fixed targets `Partystash`, `Loot`, `Sell` with a resolver function that aborts the dialog and notifies the GM if any are missing; per-item selection uses radio buttons and a single bottom action button `Items verteilen` triggering validated, batched transfers that prevent double-submits and validate source/target/item/quantity before transfer (`scripts/quickloot.js`, `templates/loot-dialog.hbs`).
- Kept the existing inventory helper `game.pf2eCombatQuickloot.showInventoryDialog()` and migrated it to `DialogV2` with mystified-name display (`scripts/inventory-dialog.js`).
- Refreshed CSS for a compact, accessible table layout and targets as radio controls (`styles/quickloot.css`).
- Updated `module.json` for Foundry V14 compatibility and explicit PF2e relationship and bumped module version to `0.2.0`.

Files changed: `scripts/quickloot.js`, `scripts/inventory-dialog.js`, `templates/loot-dialog.hbs`, `styles/quickloot.css`, `module.json`.

### Testing

- Ran `git diff --check` and it passed with no whitespace/errors reported (success).
- Performed static syntax checks with `node --check scripts/quickloot.js` and `node --check scripts/inventory-dialog.js`, both passed (no syntax errors).
- Validated `module.json` syntax using `python -m json.tool module.json` which succeeded.
- Verified presence of required static assets with `test -f templates/loot-dialog.hbs` and `test -f styles/quickloot.css`, both succeeded.

All automated checks executed in this environment passed; a full runtime integration test inside a running Foundry VTT V14 instance with PF2e (to exercise transfers, identification APIs and actual `ItemTransfer` behaviour) was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a797125f37083279b321065725a056a)