### PR TITLE
Fix resilient DialogV2 loot distribution (Foundry V14 / PF2e V14)

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -89,6 +89,7 @@
           quantity,
           identified,
           identifiable: !identified && (item.isMagical || item.isAlchemical),
+          displayName: display.name,
         };
         rows.set(key, row);
         section.items.push({
@@ -121,8 +122,9 @@
 
   function getIdentificationBaseDC(item) {
     const level = Math.trunc(Number(item.level ?? item.system?.level?.value ?? 0));
-    if (level <= -1) return 13;
-    return ITEM_DC_BY_LEVEL[Math.min(level, 25)];
+    const standardDC = level <= -1 ? 13 : ITEM_DC_BY_LEVEL[Math.min(level, 25)];
+    const pwolEnabled = game.pf2e?.settings?.variants?.pwol?.enabled === true;
+    return pwolEnabled ? standardDC - Math.max(level, 0) : standardDC;
   }
 
   function getIdentificationRarityModifier(item) {
@@ -174,11 +176,11 @@
     constructor(options, rows) {
       super(options);
       this.rows = rows;
-      this.distributing = false;
+      this._distributing = false;
     }
 
-    _onRender(context, options) {
-      super._onRender(context, options);
+    async _onRender(context, options) {
+      await super._onRender(context, options);
       this.element.querySelectorAll("button.identify").forEach((button) => {
         button.addEventListener("click", () => this._onIdentify(button.dataset.row));
       });
@@ -205,52 +207,70 @@
       try {
         await postIdentificationChecks(item);
       } catch (error) {
-        notifyError(`${PREFIX} Identifikations-Checks konnten nicht gepostet werden: ${error.message}`, error);
+        notifyError(`Identifikations-Checks konnten nicht gepostet werden: ${error.message}`, error);
       }
+    }
+
+    _removeRow(key) {
+      this.rows.delete(key);
+      const element = Array.from(this.element.querySelectorAll("tr[data-row]"))
+        .find((candidate) => candidate.dataset.row === key);
+      const section = element?.closest("section.quickloot-section");
+      element?.remove();
+      if (section && !section.querySelector("tr[data-row]")) section.remove();
     }
 
     async distribute(event, button) {
       event.preventDefault();
-      if (this.distributing) return false;
-      this.distributing = true;
+      if (this._distributing) return;
+      this._distributing = true;
       button.disabled = true;
 
-      const targets = resolveTargetActors();
-      if (!targets) {
-        this.distributing = false;
-        button.disabled = false;
-        return false;
-      }
+      try {
+        const targets = resolveTargetActors();
+        if (!targets) return;
 
-      const form = this.element.querySelector("form.quickloot");
-      const failures = [];
-      for (const [key, row] of this.rows) {
-        const targetName = new FormData(form).get(`target-${key}`);
-        const target = targets.get(targetName);
-        try {
+        const form = this.element.querySelector("form.quickloot");
+        const selections = new FormData(form);
+        let failures = 0;
+        for (const [key, row] of Array.from(this.rows)) {
           const source = await resolveSourceActor(row.sourceUuid);
           const item = source?.items.get(row.itemId);
-          if (!source) throw new Error("Source-Actor existiert nicht mehr.");
-          if (!item || item.isPhysical !== true) throw new Error("Das physische Source-Item existiert nicht mehr.");
-          if (!target) throw new Error("Der ausgewählte Target-Actor existiert nicht.");
-          const quantity = Math.min(row.quantity, Number(item.quantity ?? 0));
-          if (quantity < 1) throw new Error("Die Item-Menge ist nicht mehr verfügbar.");
-          await transferPhysicalItem(source, target, item, quantity);
-          this.rows.delete(key); // A successful row can never be submitted a second time.
-        } catch (error) {
-          console.error(`${PREFIX} Transfer von Loot-Zeile ${key} fehlgeschlagen.`, error);
-          failures.push(error.message);
-        }
-      }
+          if (!source || !item || item.isPhysical !== true) {
+            console.warn(`${PREFIX} Loot-Zeile ${key} wurde entfernt, da das Source-Item nicht mehr existiert.`);
+            this._removeRow(key);
+            continue;
+          }
 
-      if (failures.length) {
-        ui.notifications.error(`${PREFIX} ${failures.length} Transfer(s) fehlgeschlagen: ${failures.join(" ")}`);
-        this.distributing = false;
+          const targetName = selections.get(`target-${key}`);
+          const target = targets.get(targetName);
+          try {
+            if (!target) throw new Error("Der ausgewählte Target-Actor existiert nicht.");
+            const quantity = Math.min(row.quantity, Number(item.quantity ?? 0));
+            if (quantity < 1) {
+              console.warn(`${PREFIX} Loot-Zeile ${key} wurde entfernt, da keine Item-Menge mehr verfügbar ist.`);
+              this._removeRow(key);
+              continue;
+            }
+            await transferPhysicalItem(source, target, item, quantity);
+            this._removeRow(key); // A successful row can never be submitted a second time.
+          } catch (error) {
+            failures += 1;
+            notifyError(
+              `„${row.displayName}“ konnte nicht nach „${targetName ?? "unbekannt"}“ übertragen werden.`,
+              error,
+            );
+          }
+        }
+
+        if (this.rows.size === 0) {
+          if (!failures) ui.notifications.info(`${PREFIX} Loot wurde erfolgreich verteilt.`);
+          await this.close();
+        }
+      } finally {
+        this._distributing = false;
         button.disabled = false;
-        return false;
       }
-      ui.notifications.info(`${PREFIX} Alle Items wurden verteilt.`);
-      return true;
     }
   }
 
@@ -278,6 +298,7 @@
             label: "Items verteilen",
             icon: "fa-solid fa-box-open",
             default: true,
+            close: false,
             callback: (event, button) => dialog.distribute(event, button),
           },
         ],
@@ -288,7 +309,7 @@
   }
 
   Hooks.on("deleteCombat", (combat) => void showLootDialog(combat).catch((error) => {
-    notifyError(`${PREFIX} Der Loot-Dialog konnte nicht geöffnet werden.`, error);
+    notifyError("Der Loot-Dialog konnte nicht geöffnet werden.", error);
   }));
 
   const namespace = (game.pf2eCombatQuickloot ??= {});


### PR DESCRIPTION
### Motivation
- Ensure the loot `DialogV2` no longer closes on partial failures and to prevent duplicate transfers while keeping existing UI and identification behavior intact.
- Apply the PF2e Variant Rule `Proficiency Without Level` to local identification DC calculations with a safe fallback to standard DCs.
- Remove duplicated logging prefixes and make rendering compatible with ApplicationV2 without restructuring existing loot or identification logic.

### Description
- Implemented a distribution lock (`this._distributing`) and disabled the distribute button while processing, and set the distribute button `close: false` so the dialog is only closed explicitly when empty.
- Added a `_removeRow(key)` helper to remove successful or stale rows from both the internal `rows` state and the DOM so successfully transferred items are never retried and remaining items stay visible.
- Made `_onRender` asynchronous and `await super._onRender()` to be ApplicationV2-compliant while preserving existing event listeners, and avoided re-registering listeners on re-render.
- Improved per-row error handling so each failed transfer reports a safe mystified display name (no internal names/UUIDs leaked) via `notifyError`, and callers no longer prefix messages with the module prefix to avoid double-prefixing in console logs.
- Adjusted `getIdentificationBaseDC` to consult the PF2e V14 variant flag at `game.pf2e?.settings?.variants?.pwol?.enabled` and apply `standardDC - Math.max(level,0)` when enabled, falling back to the standard DC when the setting is absent or disabled.
- Kept existing transfer API usage (`source.transferItemToActor` / `item.transferToActor`) and identification helpers (`item.isIdentified`, `item.getMystifiedData`) intact and unchanged where not required.
- Added `displayName` to row data to allow safe user-facing error messages and bumped `module.json` version from `1.0.0` to `1.0.1`.

### Testing
- Ran syntax checks `node --check scripts/quickloot.js` and `node --check scripts/inventory-dialog.js`, both succeeded.
- Ran `git diff --check` and ensured no diff-check issues were present, which succeeded.
- Executed Node assertion harnesses that validated standard and PWOL identification DCs (PWOL on/off), rarity and cursed modifiers, tradition modifiers and alchemical crafting checks, and these assertions passed.
- Executed simulated-transfer tests that validated partial-transfer behavior, duplicate-click locking, that successful rows are removed and not retried, mystified-safe error messages, and automatic close when no rows remain, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7980ea5ab083279711ee902b76ae7a)