### PR TITLE
Fix V14 loot dialog distribution button — move to template and bump to 1.0.2

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -187,6 +187,10 @@
       this.element.querySelectorAll("button.item-link").forEach((button) => {
         button.addEventListener("click", () => this._onOpenItem(button.dataset.row));
       });
+      const distributeButton = this.element.querySelector(".quickloot-distribute");
+      distributeButton?.addEventListener("click", (event) => {
+        void this.distribute(event, distributeButton);
+      });
     }
 
     async _getCurrentItem(key) {
@@ -230,8 +234,6 @@
         const targets = resolveTargetActors();
         if (!targets) return;
 
-        const form = this.element.querySelector("form.quickloot");
-        const selections = new FormData(form);
         let failures = 0;
         for (const [key, row] of Array.from(this.rows)) {
           const source = await resolveSourceActor(row.sourceUuid);
@@ -242,7 +244,9 @@
             continue;
           }
 
-          const targetName = selections.get(`target-${key}`);
+          const rowElement = Array.from(this.element.querySelectorAll("tr[data-row]"))
+            .find((candidate) => candidate.dataset.row === key);
+          const targetName = rowElement?.querySelector('input[type="radio"]:checked')?.value;
           const target = targets.get(targetName);
           try {
             if (!target) throw new Error("Der ausgewählte Target-Actor existiert nicht.");
@@ -269,7 +273,7 @@
         }
       } finally {
         this._distributing = false;
-        button.disabled = false;
+        if (this.rows.size > 0) button.disabled = false;
       }
     }
   }
@@ -292,16 +296,7 @@
         position: { width: 760 },
         modal: true,
         content,
-        buttons: [
-          {
-            action: "distribute",
-            label: "Items verteilen",
-            icon: "fa-solid fa-box-open",
-            default: true,
-            close: false,
-            callback: (event, button) => dialog.distribute(event, button),
-          },
-        ],
+        buttons: [],
       },
       rows,
     );

--- a/styles/quickloot.css
+++ b/styles/quickloot.css
@@ -81,6 +81,14 @@
   padding: 0;
 }
 
+.quickloot-footer {
+  display: flex;
+}
+
+.quickloot-footer .quickloot-distribute {
+  width: 100%;
+}
+
 .quickloot.inventory td {
   text-align: left;
 }

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -1,4 +1,4 @@
-<form class="quickloot">
+<div class="quickloot">
   {{#each sections}}
     <section class="quickloot-section">
       <h3>{{this.name}}</h3>
@@ -43,4 +43,10 @@
       </table>
     </section>
   {{/each}}
-</form>
+  <footer class="quickloot-footer">
+    <button type="button" class="quickloot-distribute">
+      <i class="fa-solid fa-box-open" inert></i>
+      Items verteilen
+    </button>
+  </footer>
+</div>


### PR DESCRIPTION
### Motivation

- Foundry VTT V14 rejects the DialogV2 button option `close: false` and using a Dialog submit caused the dialog to close prematurely; the distribution action must not rely on DialogV2 submit behavior.  
- The dialog must only auto-close when all loot rows have been successfully processed, while preserving existing transfer, identification and selection logic.

### Description

- Removed the DialogV2 `distribute` button (and all uses of `close: false`) and cleared the dialog `buttons` array so no submit-based distribution remains.  
- Replaced the root `<form class="quickloot">` with `<div class="quickloot">` and added a footer button `<button type="button" class="quickloot-distribute">` into `templates/loot-dialog.hbs`.  
- Added a local click listener for `.quickloot-distribute` in `_onRender()` and adapted `distribute()` to read per-row radio selections directly from the DOM, keep `_distributing` double-click protection, disable/reenable the footer button, remove successful rows, and only call `this.close()` when `rows.size === 0`.  
- Minor CSS to present the footer button and bumped `module.json` version from `1.0.1` to `1.0.2`.

Changed files: `templates/loot-dialog.hbs`, `scripts/quickloot.js`, `styles/quickloot.css`, `module.json`.

### Testing

- Automated static checks: `node --check scripts/quickloot.js` succeeded and `node --check scripts/inventory-dialog.js` succeeded.  
- Static verification confirms removal of `close: false`, removal of the DialogV2 `distribute` button, and replacement of the form root; module version is now `1.0.2`.  
- Tests A–E (static/code-path verification): full-distribution, partial-failure, missing source-item, double-click protection and per-row radio-target routing were validated against the implemented logic and behave as specified based on the code changes.  
- Known risks: interactive integration tests in a live Foundry VTT V14 + PF2e instance were not executed here, so runtime integration risks (edge-case system API differences or permissions in a particular environment) remain possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a798405ab748327adabc5ae94aea0de)