### PR TITLE
Resolve Partystash via PF2e party actor and normalize Loot/Sell lookups (v1.0.3)

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -25,19 +25,37 @@
     ui.notifications.error(message);
   }
 
+  function normalizeName(name) {
+    return String(name ?? "").trim().toLocaleLowerCase();
+  }
+
   /** Resolve the three deliberately fixed destinations and never return partial results. */
   function resolveTargetActors({ notify = true } = {}) {
-    const actors = TARGET_NAMES.map((name) => game.actors.find((actor) => actor.name === name) ?? null);
-    const missing = TARGET_NAMES.filter((_name, index) => !actors[index]);
+    const partyActor = game.actors.party;
+    const lootActor = game.actors.find((actor) => normalizeName(actor.name) === "loot") ?? null;
+    const sellActor = game.actors.find((actor) => normalizeName(actor.name) === "sell") ?? null;
+    const missing = [!lootActor && "Loot", !sellActor && "Sell"].filter(Boolean);
+    const hasPartyActor = partyActor?.type === "party";
+
+    if (!hasPartyActor && notify) {
+      ui.notifications.error(
+        `${PREFIX} Kein aktiver PF2e-Party-Actor gefunden. Der Partystash kann nicht verwendet werden.`,
+      );
+    }
     if (missing.length) {
       if (notify) {
         ui.notifications.error(
           `${PREFIX} Folgende Ziel-Actors fehlen: ${missing.join(", ")}. Der Loot-Dialog wurde nicht geöffnet.`,
         );
       }
-      return null;
     }
-    return new Map(actors.map((actor) => [actor.name, actor]));
+    if (!hasPartyActor || missing.length) return null;
+
+    return {
+      Partystash: partyActor,
+      Loot: lootActor,
+      Sell: sellActor,
+    };
   }
 
   function isDefeated(combatant) {
@@ -247,7 +265,7 @@
           const rowElement = Array.from(this.element.querySelectorAll("tr[data-row]"))
             .find((candidate) => candidate.dataset.row === key);
           const targetName = rowElement?.querySelector('input[type="radio"]:checked')?.value;
-          const target = targets.get(targetName);
+          const target = TARGET_NAMES.includes(targetName) ? targets[targetName] : null;
           try {
             if (!target) throw new Error("Der ausgewählte Target-Actor existiert nicht.");
             const quantity = Math.min(row.quantity, Number(item.quantity ?? 0));


### PR DESCRIPTION
### Motivation

- PF2e V14 moves the stash into the Party actor, so the dialog must stop searching for a separate world Actor named `Partystash` and instead use the active PF2e party actor at `game.actors.party`.
- Keep `Loot` and `Sell` as normal World-Actors but make their lookup robust against surrounding whitespace and case differences.

### Description

- Add `normalizeName` helper and change `resolveTargetActors` to use `const partyActor = game.actors.party;` and validate `partyActor?.type === "party"` before allowing Partystash transfers.
- Continue to locate `Loot` and `Sell` via `game.actors.find(...)` using the normalized name comparison and report missing `Loot`/`Sell` as before while reporting a separate, clear notification when no party actor exists: `PF2e Combat Quickloot | Kein aktiver PF2e-Party-Actor gefunden. Der Partystash kann nicht verwendet werden.`
- Return a unified mapping object `{ Partystash: partyActor, Loot: lootActor, Sell: sellActor }` and adapt the distribution logic to index targets from this mapping while keeping the visible radio values `Partystash`, `Loot`, `Sell` unchanged.
- Ensure no other systems (transfer API usage, radio buttons, DialogV2 lifecycle, identification, partial transfers, etc.) are refactored or altered beyond the minimal changes required.
- Bump module version in `module.json` from `1.0.2` to `1.0.3`.

### Testing

- Ran `node --check scripts/quickloot.js` and `node --check scripts/inventory-dialog.js`, both succeeded.
- Executed a mocked runtime resolution test that verified `Partystash` resolves to `game.actors.party`, `Loot` and `Sell` are found with normalization, a missing party actor produces the new GM notification and prevents transfers, and a non-`party` actor is rejected; all checks passed.
- No other automated checks failed during the change validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a798f8286d083278e1f0bc816854dd2)