### PR TITLE
Use PF2e `isOfType("physical")` for item detection; bump to 1.0.4

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/inventory-dialog.js
+++ b/scripts/inventory-dialog.js
@@ -1,13 +1,17 @@
 (() => {
   "use strict";
 
+  function isPhysicalItem(item) {
+    return item?.isOfType?.("physical") === true;
+  }
+
   async function showInventoryDialog() {
     const token = canvas.tokens.controlled[0];
     if (!token?.actor) return ui.notifications.warn("Bitte zuerst einen Token auswählen.");
 
     const actor = token.actor;
     const rows = actor.items
-      .filter((item) => item.isPhysical === true)
+      .filter((item) => isPhysicalItem(item))
       .map((item) => {
         const { name } = game.pf2eCombatQuickloot.getSafeItemDisplayData(item);
         return `<tr><td>${Number(item.quantity ?? 1)} × ${foundry.utils.escapeHTML(name)}</td></tr>`;

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -62,6 +62,10 @@
     return combatant.defeated === true || Number(combatant.actor?.system?.attributes?.hp?.value) <= 0;
   }
 
+  function isPhysicalItem(item) {
+    return item?.isOfType?.("physical") === true;
+  }
+
   function isItemIdentified(item) {
     return item.isIdentified ?? item.system?.identification?.status === "identified";
   }
@@ -93,7 +97,15 @@
       if (!actor || actor.type !== "npc" || !isDefeated(combatant)) continue;
 
       const section = { name: actor.name, items: [] };
-      for (const item of actor.items.filter((candidate) => candidate.isPhysical === true)) {
+      console.debug(
+        `${PREFIX} Prüfe Inventar von "${actor.name}"`,
+        actor.items.map((item) => ({
+          name: item.name,
+          type: item.type,
+          physical: isPhysicalItem(item),
+        })),
+      );
+      for (const item of actor.items.filter((candidate) => isPhysicalItem(candidate))) {
         const quantity = Number(item.quantity ?? item.system?.quantity ?? 1);
         if (!Number.isFinite(quantity) || quantity < 1) continue;
 
@@ -256,7 +268,7 @@
         for (const [key, row] of Array.from(this.rows)) {
           const source = await resolveSourceActor(row.sourceUuid);
           const item = source?.items.get(row.itemId);
-          if (!source || !item || item.isPhysical !== true) {
+          if (!source || !item || !isPhysicalItem(item)) {
             console.warn(`${PREFIX} Loot-Zeile ${key} wurde entfernt, da das Source-Item nicht mehr existiert.`);
             this._removeRow(key);
             continue;


### PR DESCRIPTION
### Motivation
- The module used the unreliable `item.isPhysical` checks which caused real PF2e physical inventory items to be missed and non-physical entries (melee attacks, spells, effects) to be misclassified as loot.

### Description
- Added a small helper `isPhysicalItem(item)` that returns `item?.isOfType?.("physical") === true` in `scripts/quickloot.js` and `scripts/inventory-dialog.js`.
- Replaced legacy `.isPhysical` checks in three places: NPC loot collection (`actor.items.filter(...)`), transfer validation before distributing loot, and the inventory dialog filter, and retained all downstream quantity, mystification and identification logic unchanged.
- Added a browser-only `console.debug` output during NPC item collection that logs each item as `{ name, type, physical }` for practical inspection.
- Increased module version from `1.0.3` to `1.0.4` in `module.json` and left `compatibility` (`minimum`/`verified`) at `14` unchanged.

### Testing
- `node --check scripts/quickloot.js` and `node --check scripts/inventory-dialog.js` were executed and completed successfully.
- A repository-wide search for `.isPhysical` found no remaining legacy checks after the changes.
- A small Node logical test covering `weapon`, `equipment`, `consumable`, `treasure`, `melee`, `spell`, and `effect` cases passed for the new `isPhysicalItem` logic.
- `module.json` version and compatibility were validated and `git diff --check` reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79931f924083279d9f5b51ac7f4b74)