### PR TITLE
PF2e Combat Quickloot 1.0.5 — DialogV2 Close-Button für Foundry V14

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -326,7 +326,13 @@
         position: { width: 760 },
         modal: true,
         content,
-        buttons: [],
+        buttons: [
+          {
+            action: "close",
+            label: "Schließen",
+            icon: "fa-solid fa-xmark",
+          },
+        ],
       },
       rows,
     );


### PR DESCRIPTION
### Motivation
- Behebt ein Rendering-Fehler unter Foundry VTT V14, weil `DialogV2` mindestens einen Eintrag in `config.buttons` verlangt und der Loot-Dialog aktuell mit `buttons: []` initialisiert wurde.
- Ziel ist, einen unkritischen Schließen-Button hinzuzufügen, ohne die bestehende Verteilungslogik, Identifikationsverhalten oder Partystash-Auflösung zu verändern.

### Description
- Geänderte Dateien: `module.json` und `scripts/quickloot.js`.
- Erhöhte Version in `module.json` von `1.0.4` auf `1.0.5`.
- Ersetzte die leere Buttons-Konfiguration `buttons: []` durch einen einzelnen DialogV2-Button: `{ action: "close", label: "Schließen", icon: "fa-solid fa-xmark" }` und wurde ohne `callback` oder `close: false` hinzugefügt.
- Belassen der Template-Button-Implementierung `Items verteilen` in `templates/loot-dialog.hbs` und des DOM-Click-Listeners (`this.element.querySelector(".quickloot-distribute")`) unverändert; keinerlei Verteilungslogik in DialogV2-Buttons verschoben.

### Testing
- `node --check scripts/quickloot.js` — erfolgreich.
- `node --check scripts/inventory-dialog.js` — erfolgreich.
- `git diff --check` — erfolgreich.
- Zusätzlicher Node-VM Regressionstest prüfte die DialogV2-Initialisierung, dass der Template-Button die vorhandene `distribute()`-Methode aufruft, partielle Transfer-Fehler A/B korrekt beibehält und dass der neue Close-Button keinen Loot transferiert — alle Prüfungen bestanden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7995768bf08327aa13e052afc0cacf)