### PR TITLE
Verbesserter Identifikations-Workflow: nur magical/alchemical mystifizieren, Inline-Checks & Chat‑Integration — v1.0.6

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -13,6 +13,8 @@
   ]);
   const RARITY_MODIFIERS = Object.freeze({ common: 0, uncommon: 2, rare: 5, unique: 10 });
   const HARD_DC_MODIFIER = 2;
+  const IDENTIFICATION_OPTION_PREFIX = `${MODULE_ID}:identify:`;
+  const openLootRows = new Map();
   const MAGIC_TRADITION_SKILLS = Object.freeze({
     arcane: "arcana",
     primal: "nature",
@@ -66,26 +68,39 @@
     return item?.isOfType?.("physical") === true;
   }
 
-  function isItemIdentified(item) {
-    return item.isIdentified ?? item.system?.identification?.status === "identified";
+  function isQuicklootMystifiable(item) {
+    const traits = item?.traits;
+    return item?.isMagical === true || item?.isAlchemical === true
+      || traits?.has?.("magical") === true || traits?.has?.("alchemical") === true;
   }
 
-  /** Return only data that is safe to render for the item's identification state. */
-  function getSafeItemDisplayData(item) {
-    if (isItemIdentified(item)) return { name: item.name, img: item.img };
-
-    const fallback = { name: "Unidentifizierter Gegenstand", img: "icons/svg/item-bag.svg" };
+  /** Return only PF2e's substitution data, never data from the identified item. */
+  function getMystifiedDisplayData(item) {
+    const fallback = {
+      name: "Unidentifizierter Gegenstand",
+      img: "icons/svg/item-bag.svg",
+      description: "",
+    };
     if (typeof item.getMystifiedData !== "function") return fallback;
     try {
       const mystified = item.getMystifiedData("unidentified");
       return {
         name: typeof mystified?.name === "string" && mystified.name ? mystified.name : fallback.name,
         img: typeof mystified?.img === "string" && mystified.img ? mystified.img : fallback.img,
+        description: typeof mystified?.data?.description?.value === "string"
+          ? mystified.data.description.value
+          : "",
       };
     } catch (error) {
       console.warn(`${PREFIX} Mystifizierte Item-Daten konnten nicht gelesen werden.`, error);
       return fallback;
     }
+  }
+
+  /** Inventory consumers still need to respect an item's persistent PF2e identification state. */
+  function getSafeItemDisplayData(item) {
+    const identified = item.isIdentified ?? item.system?.identification?.status === "identified";
+    return identified ? { name: item.name, img: item.img } : getMystifiedDisplayData(item);
   }
 
   function collectLoot(combat) {
@@ -110,24 +125,30 @@
         if (!Number.isFinite(quantity) || quantity < 1) continue;
 
         const key = foundry.utils.randomID();
-        const identified = isItemIdentified(item);
-        const display = getSafeItemDisplayData(item);
+        const quicklootIdentified = !isQuicklootMystifiable(item);
+        const display = quicklootIdentified ? { name: item.name, img: item.img } : getMystifiedDisplayData(item);
         const row = {
           key,
           sourceUuid: actor.uuid,
+          sourceActorId: actor.id,
           itemId: item.id,
           quantity,
-          identified,
-          identifiable: !identified && (item.isMagical || item.isAlchemical),
+          target: TARGET_NAMES[0],
+          quicklootIdentified,
+          mystifiable: !quicklootIdentified,
           displayName: display.name,
+          displayImg: display.img,
         };
+        openLootRows.set(key, row);
         rows.set(key, row);
         section.items.push({
           key,
           quantity,
           name: display.name,
-          identified,
-          identifiable: row.identifiable,
+          img: display.img,
+          quicklootIdentified,
+          showIdentify: row.mystifiable && !quicklootIdentified,
+          target: row.target,
         });
       }
       if (section.items.length) sections.push(section);
@@ -172,34 +193,77 @@
 
   function getIdentificationChecks(item) {
     const dc = getIdentificationBaseDC(item) + getIdentificationRarityModifier(item);
-    if (item.isMagical === true) {
+    if (item.isMagical === true || item.traits?.has?.("magical") === true) {
       const traditions = getMagicTraditions(item);
       return Object.entries(MAGIC_TRADITION_SKILLS).map(([tradition, skill]) => ({
         skill,
         dc: dc + (traditions.size > 0 && !traditions.has(tradition) ? HARD_DC_MODIFIER : 0),
       }));
     }
-    return item.isAlchemical === true ? [{ skill: "crafting", dc }] : [];
+    return item.isAlchemical === true || item.traits?.has?.("alchemical") === true
+      ? [{ skill: "crafting", dc }]
+      : [];
   }
 
-  async function postIdentificationChecks(item) {
+  async function postIdentificationChecks(item, row) {
+    row.checkId ??= foundry.utils.randomID();
     const dcs = getIdentificationChecks(item);
     const skillLabels = CONFIG.PF2E.skills ?? CONFIG.PF2E.skillList ?? {};
     const checks = dcs
       .filter(({ dc }) => Number.isFinite(dc))
       .map(({ skill, dc }) => {
         const label = game.i18n.localize(skillLabels[skill]?.label ?? skillLabels[skill] ?? `PF2E.Skill.${skill}`);
-        return `<li>${foundry.utils.escapeHTML(label)} DC ${Number(dc)}</li>`;
+        return `@Check[${skill}|dc:${Number(dc)}|options:${IDENTIFICATION_OPTION_PREFIX}${row.checkId}]{${foundry.utils.escapeHTML(label)}}`;
       })
-      .join("");
+      .join("<br>");
     if (!checks) throw new Error("Für diesen Gegenstand sind keine Identifikations-Checks verfügbar.");
 
     // Deliberately use only mystified plain text: no UUID, link, image, price, level, traits, or description.
-    const name = foundry.utils.escapeHTML(getSafeItemDisplayData(item).name);
+    const name = foundry.utils.escapeHTML(getMystifiedDisplayData(item).name);
+    const rawContent = `<section class="pf2e-quickloot-identification"><h3>Gegenstand identifizieren</h3><p>${name}</p><p><strong>Mögliche Identifikations-Checks</strong></p>${checks}</section>`;
+    const content = await foundry.applications.ux.TextEditor.enrichHTML(rawContent, {
+      async: true,
+      secrets: false,
+    });
     await ChatMessage.create({
       user: game.user.id,
-      content: `<section class="pf2e-quickloot-identification"><h3>Gegenstand identifizieren</h3><p>${name}</p><p><strong>Mögliche Identifikations-Checks</strong></p><ul>${checks}</ul></section>`,
+      content,
+      flags: {
+        [MODULE_ID]: {
+          action: "identify",
+          rowKey: row.key,
+          sourceActorId: row.sourceActorId,
+          itemId: row.itemId,
+          checkId: row.checkId,
+        },
+      },
     });
+  }
+
+  function escapeAttribute(value) {
+    return foundry.utils.escapeHTML(String(value ?? "")).replaceAll('"', "&quot;");
+  }
+
+  async function postItemToChat(item, row) {
+    if (row.quicklootIdentified) {
+      if (typeof item.toMessage === "function") return item.toMessage(undefined, { create: true });
+      if (typeof item.toChat === "function") return item.toChat();
+      throw new Error("Die installierte PF2e-Version stellt keine Item-Chat-API bereit.");
+    }
+
+    const mystified = getMystifiedDisplayData(item);
+    const safeName = mystified.name && mystified.name !== item.name
+      ? mystified.name
+      : "Unidentifizierter Gegenstand";
+    const safeDescription = mystified.description.includes(item.name) || /@UUID\s*\[/i.test(mystified.description)
+      ? ""
+      : mystified.description;
+    // This deliberately has no UUID, item data attributes, level, price, traits, runes, or hidden elements.
+    const content = `<article class="pf2e-quickloot-mystified"><header><img src="${escapeAttribute(mystified.img)}" alt="Unidentifizierter Gegenstand"><h3>${foundry.utils.escapeHTML(safeName)}</h3></header><p>${foundry.utils.escapeHTML(safeDescription)}</p></article>`;
+    if (content.includes(item.name) || /@UUID\s*\[/i.test(content)) {
+      throw new Error("Der mystifizierte Chat-Inhalt hat die Sicherheitsprüfung nicht bestanden.");
+    }
+    return ChatMessage.create({ user: game.user.id, content });
   }
 
   class QuickLootDialog extends foundry.applications.api.DialogV2 {
@@ -213,6 +277,15 @@
       await super._onRender(context, options);
       this.element.querySelectorAll("button.identify").forEach((button) => {
         button.addEventListener("click", () => this._onIdentify(button.dataset.row));
+      });
+      this.element.querySelectorAll("button.quickloot-chat").forEach((button) => {
+        button.addEventListener("click", () => this._onChat(button.dataset.row));
+      });
+      this.element.querySelectorAll('input[type="radio"][data-row]').forEach((input) => {
+        input.addEventListener("change", () => {
+          const row = this.rows.get(input.dataset.row);
+          if (row && TARGET_NAMES.includes(input.value)) row.target = input.value;
+        });
       });
       this.element.querySelectorAll("button.item-link").forEach((button) => {
         button.addEventListener("click", () => this._onOpenItem(button.dataset.row));
@@ -232,21 +305,45 @@
     async _onOpenItem(key) {
       const { row, item } = await this._getCurrentItem(key);
       // Sheets are offered only for identified items. This is a second guard against forged DOM events.
-      if (row?.identified && item?.isIdentified !== false) item.sheet.render({ force: true });
+      if (row?.quicklootIdentified) item?.sheet.render({ force: true });
     }
 
     async _onIdentify(key) {
       const { row, item } = await this._getCurrentItem(key);
       if (!row || !item) return ui.notifications.error(`${PREFIX} Der Gegenstand existiert nicht mehr.`);
       try {
-        await postIdentificationChecks(item);
+        if (!row.mystifiable || row.quicklootIdentified) return;
+        await postIdentificationChecks(item, row);
       } catch (error) {
         notifyError(`Identifikations-Checks konnten nicht gepostet werden: ${error.message}`, error);
       }
     }
 
+    async _onChat(key) {
+      const { row, item } = await this._getCurrentItem(key);
+      if (!row || !item) return ui.notifications.error(`${PREFIX} Der Gegenstand existiert nicht mehr.`);
+      try {
+        await postItemToChat(item, row);
+      } catch (error) {
+        notifyError(`Der Gegenstand konnte nicht in den Chat gepostet werden: ${error.message}`, error);
+      }
+    }
+
+    revealRow(key) {
+      const row = this.rows.get(key);
+      const element = this.element.querySelector(`tr[data-row="${CSS.escape(key)}"]`);
+      if (!row || !element) return;
+      const nameCell = element.querySelector("td.item-name");
+      if (nameCell) {
+        nameCell.innerHTML = `<img src="${escapeAttribute(row.displayImg)}" alt=""><button type="button" class="item-link" data-row="${escapeAttribute(key)}">${foundry.utils.escapeHTML(row.displayName)}</button>`;
+        nameCell.querySelector("button.item-link")?.addEventListener("click", () => this._onOpenItem(key));
+      }
+      element.querySelector("button.identify")?.remove();
+    }
+
     _removeRow(key) {
       this.rows.delete(key);
+      openLootRows.delete(key);
       const element = Array.from(this.element.querySelectorAll("tr[data-row]"))
         .find((candidate) => candidate.dataset.row === key);
       const section = element?.closest("section.quickloot-section");
@@ -276,7 +373,7 @@
 
           const rowElement = Array.from(this.element.querySelectorAll("tr[data-row]"))
             .find((candidate) => candidate.dataset.row === key);
-          const targetName = rowElement?.querySelector('input[type="radio"]:checked')?.value;
+          const targetName = row.target;
           const target = TARGET_NAMES.includes(targetName) ? targets[targetName] : null;
           try {
             if (!target) throw new Error("Der ausgewählte Target-Actor existiert nicht.");
@@ -337,7 +434,57 @@
       rows,
     );
     dialog.render({ force: true });
+    for (const row of rows.values()) row.dialog = dialog;
   }
+
+  function getIdentificationOutcome(message) {
+    const outcome = message.flags?.pf2e?.context?.outcome;
+    if (["criticalFailure", "failure", "success", "criticalSuccess"].includes(outcome)) return outcome;
+    const degree = message.rolls?.find((roll) => Number.isInteger(roll.degreeOfSuccess))?.degreeOfSuccess;
+    return ["criticalFailure", "failure", "success", "criticalSuccess"][degree] ?? null;
+  }
+
+  function getIdentificationFlagFromRoll(message) {
+    const options = message.flags?.pf2e?.context?.options;
+    const option = Array.isArray(options)
+      ? options.find((value) => String(value).startsWith(IDENTIFICATION_OPTION_PREFIX))
+      : null;
+    const checkId = option?.slice(IDENTIFICATION_OPTION_PREFIX.length);
+    if (!checkId) return null;
+    return game.messages.find((candidate) => {
+      const flag = candidate.flags?.[MODULE_ID];
+      return flag?.action === "identify" && flag.checkId === checkId;
+    })?.flags?.[MODULE_ID] ?? null;
+  }
+
+  async function identifyFromRoll(message) {
+    const activeGM = game.users.activeGM;
+    if (!game.user.isGM || (activeGM && activeGM.id !== game.user.id)) return;
+    if (!["success", "criticalSuccess"].includes(getIdentificationOutcome(message))) return;
+    const flag = getIdentificationFlagFromRoll(message);
+    const row = flag ? openLootRows.get(flag.rowKey) : null;
+    if (!row || row.quicklootIdentified || row.sourceActorId !== flag.sourceActorId || row.itemId !== flag.itemId) return;
+
+    row.quicklootIdentified = true;
+    const source = game.actors.get(row.sourceActorId);
+    const item = source?.items.get(row.itemId);
+    if (item) {
+      row.displayName = item.name;
+      row.displayImg = item.img;
+    }
+    row.dialog?.revealRow(row.key);
+
+    if (item && isPhysicalItem(item) && typeof item.setIdentificationStatus === "function") {
+      try {
+        await item.setIdentificationStatus("identified");
+      } catch (error) {
+        console.warn(`${PREFIX} Das Source-Item konnte nicht persistent identifiziert werden.`, error);
+      }
+    }
+  }
+
+  Hooks.on("createChatMessage", (message) => void identifyFromRoll(message));
+  Hooks.on("updateChatMessage", (message) => void identifyFromRoll(message));
 
   Hooks.on("deleteCombat", (combat) => void showLootDialog(combat).catch((error) => {
     notifyError("Der Loot-Dialog konnte nicht geöffnet werden.", error);
@@ -350,6 +497,9 @@
     getIdentificationRarityModifier,
     getMagicTraditions,
     getSafeItemDisplayData,
+    getMystifiedDisplayData,
+    isQuicklootMystifiable,
+    postItemToChat,
     postIdentificationChecks,
     resolveTargetActors,
     showLootDialog,

--- a/styles/quickloot.css
+++ b/styles/quickloot.css
@@ -40,6 +40,15 @@
   text-align: left;
 }
 
+.quickloot .item-name img {
+  width: 2rem;
+  height: 2rem;
+  margin-right: 0.35rem;
+  border: 0;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
 .quickloot button.item-link {
   width: auto;
   min-height: 0;
@@ -70,8 +79,9 @@
 }
 
 .quickloot .actions {
-  width: 2.25rem;
+  width: 4.25rem;
   text-align: center;
+  white-space: nowrap;
 }
 
 .quickloot .actions button {

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -7,8 +7,8 @@
           <tr>
             <th class="quantity">Menge</th>
             <th class="item-name">Gegenstand</th>
+            <th class="actions">Aktionen</th>
             {{#each ../targets}}<th class="target">{{this}}</th>{{/each}}
-            <th class="actions"><span class="sr-only">Aktionen</span></th>
           </tr>
         </thead>
         <tbody>
@@ -16,27 +16,31 @@
             <tr data-row="{{this.key}}">
               <td class="quantity">{{this.quantity}} ×</td>
               <td class="item-name">
-                {{#if this.identified}}
+                <img src="{{this.img}}" alt="">
+                {{#if this.quicklootIdentified}}
                   <button type="button" class="item-link" data-row="{{this.key}}">{{this.name}}</button>
                 {{else}}
                   <span>{{this.name}}</span>
                 {{/if}}
               </td>
+              <td class="actions">
+                {{#if this.showIdentify}}
+                  <button type="button" class="identify" data-row="{{this.key}}" title="Identifikations-Checks anzeigen" aria-label="Identifikations-Checks anzeigen">
+                    <i class="fa-solid fa-magnifying-glass" inert></i>
+                  </button>
+                {{/if}}
+                <button type="button" class="quickloot-chat" data-row="{{this.key}}" title="In Chat posten" aria-label="In Chat posten">
+                  <i class="fa-solid fa-comment" inert></i>
+                </button>
+              </td>
               {{#each ../../targets}}
                 <td class="target">
                   <label title="{{this}}">
-                    <input type="radio" name="target-{{../key}}" value="{{this}}" {{#if @first}}checked{{/if}}>
+                    <input type="radio" name="target-{{../key}}" data-row="{{../key}}" value="{{this}}" {{#if (eq this ../target)}}checked{{/if}}>
                     <span class="sr-only">{{this}}</span>
                   </label>
                 </td>
               {{/each}}
-              <td class="actions">
-                {{#if this.identifiable}}
-                  <button type="button" class="identify" data-row="{{this.key}}" title="Mögliche Identifikations-Checks posten" aria-label="Mögliche Identifikations-Checks posten">
-                    <i class="fa-solid fa-magnifying-glass" inert></i>
-                  </button>
-                {{/if}}
-              </td>
             </tr>
           {{/each}}
         </tbody>


### PR DESCRIPTION
### Motivation
- Reduziere unnötige Mystifizierung und sichere den Identification-/Chat-Workflow für Quickloot unter Foundry V14 / PF2e 8.x.
- Erzeuge klickbare PF2e Inline-Check‑Links mit korrekter Zuordnung Roll→Loot‑Zeile und sichere, leak‑freie Chat‑Posts für mystifizierte Items.

### Description
- Nur noch automatisch mystifizieren, wenn `item.isMagical === true || item.isAlchemical === true` (oder über `item.traits?.has(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a799c769c008327b203ebb334dc993b)