### PR TITLE
Make Quickloot dialog non-modal and bump version to 1.0.7

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -421,7 +421,7 @@
         id: `${MODULE_ID}-dialog`,
         window: { title: "PF2e Combat Quickloot" },
         position: { width: 760 },
-        modal: true,
+        modal: false,
         content,
         buttons: [
           {


### PR DESCRIPTION
### Motivation
- Der Quickloot-Dialog soll die übrige Foundry-VTT-Oberfläche nicht mehr blockieren, damit Benutzer während geöffneter Quickloot-Dialoge weiterhin Chat lesen/öffnen, Actor-Sheets und Tokens bedienen und andere Applications verwenden können.

### Description
- In `scripts/quickloot.js` wurde `modal: true` zu `modal: false` geändert und in `module.json` die Versionsnummer von `1.0.6` auf `1.0.7` erhöht; sonstige Quickloot-/Inventory-Logik blieb unverändert.

### Testing
- Automatisierte Prüfungen `node --check scripts/quickloot.js` und `node --check scripts/inventory-dialog.js` wurden ausgeführt und sind erfolgreich gewesen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79b86dfe648327907077d93d018106)