### PR TITLE
Synchronisiere Identification-Status vor Loot-Transfer; Version 1.0.8

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -171,6 +171,15 @@
     throw new Error("Die installierte PF2e-Version stellt keine unterstützte Item-Transfer-API bereit.");
   }
 
+  /** Keep PF2e's persistent status aligned with the state shown in Quickloot before transfer. */
+  async function synchronizeIdentificationStatus(item, row) {
+    if (!row.mystifiable || !isPhysicalItem(item)) return;
+    if (typeof item.setIdentificationStatus !== "function") return;
+
+    const status = row.quicklootIdentified ? "identified" : "unidentified";
+    await item.setIdentificationStatus(status);
+  }
+
   function getIdentificationBaseDC(item) {
     const level = Math.trunc(Number(item.level ?? item.system?.level?.value ?? 0));
     const standardDC = level <= -1 ? 13 : ITEM_DC_BY_LEVEL[Math.min(level, 25)];
@@ -383,6 +392,7 @@
               this._removeRow(key);
               continue;
             }
+            await synchronizeIdentificationStatus(item, row);
             await transferPhysicalItem(source, target, item, quantity);
             this._removeRow(key); // A successful row can never be submitted a second time.
           } catch (error) {


### PR DESCRIPTION
### Motivation

- Beim Verteilen von Quickloot wurde der Dialog-Status `row.quicklootIdentified` nicht vor dem Transfer auf das persistente PF2e-Item synchronisiert, sodass magische/alchemistische Items fälschlich als identifiziert im Ziel landeten.

### Description

- Zwei Dateien geändert: `scripts/quickloot.js` und `module.json` (Version auf `1.0.8` erhöht).
- Neue Hilfsfunktion `synchronizeIdentificationStatus(item, row)` in `scripts/quickloot.js`, die nur für `row.mystifiable === true` physische Items den PF2e-Status mittels `item.setIdentificationStatus(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79bbbc6e3c8327a8821a3040c62652)