### PR TITLE
Add manual reveal per-item, Identify All button, and mystified-name chat headers (v1.0.9)

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -148,6 +148,7 @@
           img: display.img,
           quicklootIdentified,
           showIdentify: row.mystifiable && !quicklootIdentified,
+          showReveal: row.mystifiable && !quicklootIdentified,
           target: row.target,
         });
       }
@@ -214,6 +215,13 @@
       : [];
   }
 
+  /** Never fall back to the actual item name while Quickloot still treats an item as mystified. */
+  function getSafeMystifiedName(item, mystified = getMystifiedDisplayData(item)) {
+    return mystified.name && mystified.name !== item.name
+      ? mystified.name
+      : "Unidentifizierter Gegenstand";
+  }
+
   async function postIdentificationChecks(item, row) {
     row.checkId ??= foundry.utils.randomID();
     const dcs = getIdentificationChecks(item);
@@ -228,8 +236,9 @@
     if (!checks) throw new Error("Für diesen Gegenstand sind keine Identifikations-Checks verfügbar.");
 
     // Deliberately use only mystified plain text: no UUID, link, image, price, level, traits, or description.
-    const name = foundry.utils.escapeHTML(getMystifiedDisplayData(item).name);
-    const rawContent = `<section class="pf2e-quickloot-identification"><h3>Gegenstand identifizieren</h3><p>${name}</p><p><strong>Mögliche Identifikations-Checks</strong></p>${checks}</section>`;
+    const mystified = getMystifiedDisplayData(item);
+    const safeName = foundry.utils.escapeHTML(getSafeMystifiedName(item, mystified));
+    const rawContent = `<section class="pf2e-quickloot-identification"><h3 class="pf2e-quickloot-mystified-name">${safeName}</h3><p><strong>Gegenstand identifizieren</strong></p><p><strong>Mögliche Identifikations-Checks</strong></p>${checks}</section>`;
     const content = await foundry.applications.ux.TextEditor.enrichHTML(rawContent, {
       async: true,
       secrets: false,
@@ -261,14 +270,12 @@
     }
 
     const mystified = getMystifiedDisplayData(item);
-    const safeName = mystified.name && mystified.name !== item.name
-      ? mystified.name
-      : "Unidentifizierter Gegenstand";
+    const safeName = getSafeMystifiedName(item, mystified);
     const safeDescription = mystified.description.includes(item.name) || /@UUID\s*\[/i.test(mystified.description)
       ? ""
       : mystified.description;
     // This deliberately has no UUID, item data attributes, level, price, traits, runes, or hidden elements.
-    const content = `<article class="pf2e-quickloot-mystified"><header><img src="${escapeAttribute(mystified.img)}" alt="Unidentifizierter Gegenstand"><h3>${foundry.utils.escapeHTML(safeName)}</h3></header><p>${foundry.utils.escapeHTML(safeDescription)}</p></article>`;
+    const content = `<article class="pf2e-quickloot-mystified"><h3 class="pf2e-quickloot-mystified-name">${foundry.utils.escapeHTML(safeName)}</h3><img src="${escapeAttribute(mystified.img)}" alt="Unidentifizierter Gegenstand"><p>${foundry.utils.escapeHTML(safeDescription)}</p></article>`;
     if (content.includes(item.name) || /@UUID\s*\[/i.test(content)) {
       throw new Error("Der mystifizierte Chat-Inhalt hat die Sicherheitsprüfung nicht bestanden.");
     }
@@ -280,12 +287,16 @@
       super(options);
       this.rows = rows;
       this._distributing = false;
+      this._identifyingAll = false;
     }
 
     async _onRender(context, options) {
       await super._onRender(context, options);
       this.element.querySelectorAll("button.identify").forEach((button) => {
         button.addEventListener("click", () => this._onIdentify(button.dataset.row));
+      });
+      this.element.querySelectorAll("button.quickloot-reveal").forEach((button) => {
+        button.addEventListener("click", () => this._onReveal(button.dataset.row));
       });
       this.element.querySelectorAll("button.quickloot-chat").forEach((button) => {
         button.addEventListener("click", () => this._onChat(button.dataset.row));
@@ -302,6 +313,10 @@
       const distributeButton = this.element.querySelector(".quickloot-distribute");
       distributeButton?.addEventListener("click", (event) => {
         void this.distribute(event, distributeButton);
+      });
+      const identifyAllButton = this.element.querySelector(".quickloot-identify-all");
+      identifyAllButton?.addEventListener("click", () => {
+        void this._onIdentifyAll(identifyAllButton);
       });
     }
 
@@ -328,6 +343,60 @@
       }
     }
 
+    async _onReveal(key) {
+      const { row, item } = await this._getCurrentItem(key);
+      if (!row || !item || !row.mystifiable || row.quicklootIdentified) return;
+
+      row.quicklootIdentified = true;
+      row.displayName = item.name;
+      row.displayImg = item.img;
+      this.revealRow(key);
+
+      if (typeof item.setIdentificationStatus !== "function") {
+        console.warn(`${PREFIX} Das Source-Item unterstützt keine persistente Identifikation.`);
+        ui.notifications.warn(`${PREFIX} Der persistente PF2e-Status konnte nicht aktualisiert werden.`);
+        return;
+      }
+      try {
+        await item.setIdentificationStatus("identified");
+      } catch (error) {
+        console.warn(`${PREFIX} Das Source-Item konnte nicht persistent identifiziert werden.`, error);
+        ui.notifications.warn(`${PREFIX} Der persistente PF2e-Status konnte nicht aktualisiert werden.`);
+      }
+    }
+
+    async _onIdentifyAll(button) {
+      if (this._identifyingAll) return;
+      this._identifyingAll = true;
+      button.disabled = true;
+      try {
+        const candidates = Array.from(this.rows.values())
+          .filter((row) => row.mystifiable && !row.quicklootIdentified);
+        if (!candidates.length) {
+          ui.notifications.info("Es gibt keine nicht identifizierten Gegenstände.");
+          return;
+        }
+
+        for (const row of candidates) {
+          try {
+            const current = await this._getCurrentItem(row.key);
+            if (!current.row || !current.item) {
+              console.warn(`${PREFIX} Identifikations-Checks für Loot-Zeile ${row.key} wurden übersprungen: Source-Item fehlt.`);
+              continue;
+            }
+            // Recheck after awaiting the source actor so a concurrent reveal remains idempotent.
+            if (!current.row.mystifiable || current.row.quicklootIdentified) continue;
+            await postIdentificationChecks(current.item, current.row);
+          } catch (error) {
+            console.warn(`${PREFIX} Identifikations-Checks für Loot-Zeile ${row.key} konnten nicht gepostet werden.`, error);
+          }
+        }
+      } finally {
+        this._identifyingAll = false;
+        button.disabled = false;
+      }
+    }
+
     async _onChat(key) {
       const { row, item } = await this._getCurrentItem(key);
       if (!row || !item) return ui.notifications.error(`${PREFIX} Der Gegenstand existiert nicht mehr.`);
@@ -348,6 +417,7 @@
         nameCell.querySelector("button.item-link")?.addEventListener("click", () => this._onOpenItem(key));
       }
       element.querySelector("button.identify")?.remove();
+      element.querySelector("button.quickloot-reveal")?.remove();
     }
 
     _removeRow(key) {

--- a/styles/quickloot.css
+++ b/styles/quickloot.css
@@ -93,10 +93,13 @@
 
 .quickloot-footer {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-.quickloot-footer .quickloot-distribute {
-  width: 100%;
+.quickloot-footer button {
+  flex: 1 1 14rem;
+  margin: 0;
 }
 
 .quickloot.inventory td {

--- a/templates/loot-dialog.hbs
+++ b/templates/loot-dialog.hbs
@@ -29,6 +29,11 @@
                     <i class="fa-solid fa-magnifying-glass" inert></i>
                   </button>
                 {{/if}}
+                {{#if this.showReveal}}
+                  <button type="button" class="quickloot-reveal" data-row="{{this.key}}" title="Gegenstand entmystifizieren" aria-label="Gegenstand entmystifizieren">
+                    <i class="fa-solid fa-eye" inert></i>
+                  </button>
+                {{/if}}
                 <button type="button" class="quickloot-chat" data-row="{{this.key}}" title="In Chat posten" aria-label="In Chat posten">
                   <i class="fa-solid fa-comment" inert></i>
                 </button>
@@ -48,6 +53,10 @@
     </section>
   {{/each}}
   <footer class="quickloot-footer">
+    <button type="button" class="quickloot-identify-all" title="Alle nicht identifizierten Gegenstände in den Chat posten">
+      <i class="fa-solid fa-magnifying-glass" inert></i>
+      Alle identifizieren
+    </button>
     <button type="button" class="quickloot-distribute">
       <i class="fa-solid fa-box-open" inert></i>
       Items verteilen


### PR DESCRIPTION
### Motivation

- Provide GMs a manual way to reveal (identify) individual mystified items and a bulk action to post identification checks for all remaining mystified items. 
- Make mystified item names clearly visible as the header in identification and mystified chat posts while preserving existing safety behavior.
- Bump the module version to 1.0.9.

### Description

- Bumped module version to `1.0.9` in `module.json`.
- Templates: added a per-item reveal button (`button.quickloot-reveal`) and a footer `Alle identifizieren` button (`.quickloot-identify-all`) in `templates/loot-dialog.hbs`. (renders only when the row is mystifiable and not yet identified via `showReveal`).
- JS: exposed `showReveal` in row data and implemented `QuickLootDialog._onReveal(key)` which marks the row identified, updates `displayName`/`displayImg`, calls `revealRow(key)`, and attempts to call `item.setIdentificationStatus("identified")` with error-tolerance; ensured idempotence and DOM safety by early-return guards. 
- JS: implemented `QuickLootDialog._onIdentifyAll(button)` to iterate relevant rows (`row.mystifiable && !row.quicklootIdentified`), post identification checks per item via existing `postIdentificationChecks(item, row)`, skip missing items, and continue on per-item errors while disabling the button during processing.
- Chat/posts: added `getSafeMystifiedName()` and changed `postIdentificationChecks()` and `postItemToChat()` to render the PF2e-provided mystified name as a prominent heading in identification and mystified item chat messages while preserving the secure/no-UUID behavior.
- UI: updated `revealRow()` to also remove the reveal button after reveal, and adjusted footer layout/CSS in `styles/quickloot.css` to place `Alle identifizieren` next to `Items verteilen` with responsive wrapping.

### Testing

- `node --check scripts/quickloot.js` — success.
- `node --check scripts/inventory-dialog.js` — success.
- `git diff --check` and syntax/structure checks performed — success (no JS syntax errors detected and structural assertions passed verifying presence of new buttons, handlers, safe mystified headers, reveal behavior, and version bump).
- Note: interactive and integration tests (visual behavior in a running Foundry VTT V14 + PF2e world covering scenarios A–H described in the changelist) require a live Foundry instance and were not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b0a5220d88327a40dde69e1059470)