### PR TITLE
Identification-Checks als secret & automatischer Chat-Post für identifizierte Items

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-combat-quickloot",
   "title": "PF2e Combat Quickloot",
   "description": "Zeigt dem GM nach dem Kampf einen gemeinsamen Loot-Dialog mit Verteilungs- und Identifikationsfunktionen.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "authors": [
     {
       "name": "Kazgul1987"

--- a/scripts/quickloot.js
+++ b/scripts/quickloot.js
@@ -230,7 +230,7 @@
       .filter(({ dc }) => Number.isFinite(dc))
       .map(({ skill, dc }) => {
         const label = game.i18n.localize(skillLabels[skill]?.label ?? skillLabels[skill] ?? `PF2E.Skill.${skill}`);
-        return `@Check[${skill}|dc:${Number(dc)}|options:${IDENTIFICATION_OPTION_PREFIX}${row.checkId}]{${foundry.utils.escapeHTML(label)}}`;
+        return `@Check[${skill}|dc:${Number(dc)}|traits:secret|options:${IDENTIFICATION_OPTION_PREFIX}${row.checkId}]{${foundry.utils.escapeHTML(label)}}`;
       })
       .join("<br>");
     if (!checks) throw new Error("Für diesen Gegenstand sind keine Identifikations-Checks verfügbar.");
@@ -548,17 +548,26 @@
     row.quicklootIdentified = true;
     const source = game.actors.get(row.sourceActorId);
     const item = source?.items.get(row.itemId);
+    if (item && isPhysicalItem(item) && typeof item.setIdentificationStatus === "function") {
+      try {
+        await item.setIdentificationStatus("identified");
+      } catch (error) {
+        console.warn(`${PREFIX} Das Source-Item konnte nicht persistent identifiziert werden.`, error);
+      }
+    }
+
     if (item) {
       row.displayName = item.name;
       row.displayImg = item.img;
     }
     row.dialog?.revealRow(row.key);
 
-    if (item && isPhysicalItem(item) && typeof item.setIdentificationStatus === "function") {
+    if (item) {
       try {
-        await item.setIdentificationStatus("identified");
+        await postItemToChat(item, row);
       } catch (error) {
-        console.warn(`${PREFIX} Das Source-Item konnte nicht persistent identifiziert werden.`, error);
+        console.error(`${PREFIX} Der automatisch identifizierte Gegenstand konnte nicht in den Chat gepostet werden.`, error);
+        ui.notifications.warn(`${PREFIX} Der Gegenstand wurde identifiziert, aber der automatische Chat-Post ist fehlgeschlagen.`);
       }
     }
   }


### PR DESCRIPTION
### Motivation
- Identification-Checks sollen als PF2e-Secret-Rolls gewürfelt werden, damit der GM-Erfolg unabhängig von der Sichtbarkeit des Roll-Outputs ausgewertet werden kann.
- Wird ein Item durch einen erfolgreichen/crit-success Identification-Check automatisch identifiziert, soll die identifizierte Version direkt in den Chat gepostet werden, damit die Chat-Karte den identifizierten Zustand zeigt.
- Bestehende Idempotenz-, GM-Guard- und Erfolgsauswertungslogik soll unverändert bleiben und ein fehlerhafter Chat-Post darf die Identifikation nicht rückgängig machen.

### Description
- Alle dynamisch generierten Inline-Checks wurden um das Trait `traits:secret` erweitert, indem die erzeugte Syntax in `postIdentificationChecks` auf `@Check[<skill>|dc:<dc>|traits:secret|options:<checkId>]` geändert wurde.
- Der Roll-Handler `identifyFromRoll` setzt weiterhin `row.quicklootIdentified = true`, aktualisiert persistent das Source-Item mittels `item.setIdentificationStatus("identified")` falls verfügbar, enthüllt die Row und ruft danach `postItemToChat(item, row)` auf, sodass die Chat-Karte die identifizierte Version zeigt.
- Fehler beim automatischen Chat-Post werden separat mit `console.error` und einer GM-Warnung (`ui.notifications.warn`) behandelt, ohne die Identifikation zurückzunehmen.
- Die Modulversion in `module.json` wurde von `1.1.0` auf `1.1.1` erhöht.

### Testing
- `node --check scripts/quickloot.js` wurde ausgeführt und erfolgreich beendet.
- `node --check scripts/inventory-dialog.js` wurde ausgeführt und erfolgreich beendet.
- Eine automatische Verifikation via Node-Snippet bestätigte, dass `|traits:secret|options:` in `scripts/quickloot.js` vorhanden ist und `await postItemToChat(item, row)` sowie die Version `1.1.1` gesetzt sind, und lief erfolgreich.
- `git diff --check` wurde ausgeführt und zeigte keine whitespace-/diff-Fehler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b289fcdd8832786b9490a06257577)